### PR TITLE
added network interface that can have  a public ip when in dual subn

### DIFF
--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -478,7 +478,12 @@ Resources:
           Ebs:
             VolumeSize: !Ref RootVolumeSize
             Encrypted: true
-      SubnetId: !Ref Subnet
+      NetworkInterfaces:
+      - DeviceIndex: 0
+        SubnetId: !Ref Subnet
+        GroupSet:
+          - !GetAtt AiUnlimitedSecurityGroup.GroupId
+        AssociatePublicIpAddress: !If [HASPUBLICIP, true, !Ref "AWS::NoValue"]
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
       KeyName: !If
@@ -486,8 +491,8 @@ Resources:
         - !Ref KeyName
         - !Ref AWS::NoValue
       DisableApiTermination: !Ref TerminationProtection
-      SecurityGroupIds:
-        - !GetAtt AiUnlimitedSecurityGroup.GroupId
+      # SecurityGroupIds:
+      #   - !GetAtt AiUnlimitedSecurityGroup.GroupId
       IamInstanceProfile: !Ref AiUnlimitedInstanceProfile
       Volumes:
         - !If


### PR DESCRIPTION
When deploying in a public subnet in a vpc with both private and public subnet a public ip address not assigned to the server instance. This addresses this. Was able to deploy the server with ip address. Confirmed docker instances are running (thus the server has public access)