### PR TITLE
fix use persistent volume syntax issue on jupyter without lb template in aws

### DIFF
--- a/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
@@ -370,7 +370,6 @@ Resources:
               - USENEWPERSISTENTVOLUME
               - prepare_new_storage
               - !Ref AWS::NoValue
-              - USEPERSISTENTVOLUME
             - bind_storage
             - mount_storage
             - install_docker


### PR DESCRIPTION
Remove unwanted line leftover from cleanup of volume options