### PR TITLE
Removed alb components from the resources template.

### DIFF
--- a/deployments/azure/templates/arm/init/resources.json
+++ b/deployments/azure/templates/arm/init/resources.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.27.1.19265",
-      "templateHash": "18237593260730113827"
+      "templateHash": "4707887880859282690"
     }
   },
   "parameters": {
@@ -30,20 +30,6 @@
       "defaultValue": "10.0.0.0/24",
       "metadata": {
         "description": "New subnet CIDR."
-      }
-    },
-    "albSubnetCidr": {
-      "type": "string",
-      "defaultValue": "10.0.1.0/24",
-      "metadata": {
-        "description": "Application Load Balancer subnet CIDR."
-      }
-    },
-    "deployALBComponents": {
-      "type": "bool",
-      "defaultValue": false,
-      "metadata": {
-        "description": "deploy ALB components"
       }
     },
     "Tags": {
@@ -166,12 +152,6 @@
           "location": {
             "value": "[variables('location')]"
           },
-          "albSubnetCidr": {
-            "value": "[parameters('albSubnetCidr')]"
-          },
-          "deployAlbSubnet": {
-            "value": "[parameters('deployALBComponents')]"
-          },
           "tags": {
             "value": "[parameters('Tags')]"
           }
@@ -183,7 +163,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.27.1.19265",
-              "templateHash": "2707292976893196822"
+              "templateHash": "6905809493163786927"
             }
           },
           "parameters": {
@@ -196,12 +176,6 @@
             "subnetCidr": {
               "type": "string"
             },
-            "albSubnetCidr": {
-              "type": "string"
-            },
-            "deployAlbSubnet": {
-              "type": "bool"
-            },
             "location": {
               "type": "string"
             },
@@ -209,9 +183,6 @@
               "type": "object",
               "defaultValue": {}
             }
-          },
-          "variables": {
-            "gwSubnetName": "[format('{0}-gtw-subnet', parameters('networkName'))]"
           },
           "resources": [
             {
@@ -235,20 +206,6 @@
                 ]
               },
               "tags": "[parameters('tags')]"
-            },
-            {
-              "condition": "[parameters('deployAlbSubnet')]",
-              "type": "Microsoft.Network/virtualNetworks/subnets",
-              "apiVersion": "2022-11-01",
-              "name": "[format('{0}/{1}', parameters('networkName'), variables('gwSubnetName'))]",
-              "properties": {
-                "addressPrefix": "[parameters('albSubnetCidr')]",
-                "privateEndpointNetworkPolicies": "Enabled",
-                "privateLinkServiceNetworkPolicies": "Enabled"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('networkName'))]"
-              ]
             }
           ],
           "outputs": {
@@ -259,10 +216,6 @@
             "subnetName": {
               "type": "string",
               "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('networkName')), '2022-11-01').subnets[0].name]"
-            },
-            "albSubnetName": {
-              "type": "string",
-              "value": "[if(parameters('deployAlbSubnet'), variables('gwSubnetName'), '')]"
             }
           }
         }
@@ -284,10 +237,6 @@
     "SubnetName": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('name')), 'Microsoft.Resources/deployments', 'networkDeployment'), '2022-09-01').outputs.subnetName.value]"
-    },
-    "ALBSubnetName": {
-      "type": "string",
-      "value": "[if(parameters('deployALBComponents'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('name')), 'Microsoft.Resources/deployments', 'networkDeployment'), '2022-09-01').outputs.subnetName.value, '')]"
     }
   }
 }

--- a/deployments/azure/templates/init/network.bicep
+++ b/deployments/azure/templates/init/network.bicep
@@ -1,12 +1,8 @@
 param networkName string
 param networkCidr array
 param subnetCidr string
-param albSubnetCidr string
-param deployAlbSubnet bool
 param location string
 param tags object = {}
-
-var gwSubnetName = '${networkName}-gtw-subnet'
 
 resource network 'Microsoft.Network/virtualNetworks@2022-11-01' = {
   name: networkName
@@ -30,17 +26,5 @@ resource network 'Microsoft.Network/virtualNetworks@2022-11-01' = {
   tags: tags
 }
 
-resource gwSubnet 'Microsoft.Network/virtualNetworks/subnets@2022-11-01' = if (deployAlbSubnet) { 
-  parent: network
-  name: gwSubnetName
-
-  properties: {
-    addressPrefix: albSubnetCidr
-    privateEndpointNetworkPolicies: 'Enabled'
-    privateLinkServiceNetworkPolicies: 'Enabled'
-  }
-}
-
 output networkName string = network.name
 output subnetName string = network.properties.subnets[0].name
-output albSubnetName string = deployAlbSubnet ? gwSubnet.name : ''

--- a/deployments/azure/templates/init/resources.bicep
+++ b/deployments/azure/templates/init/resources.bicep
@@ -9,12 +9,6 @@ param networkCidr array = [ '10.0.0.0/16' ]
 @description('New subnet CIDR.')
 param subnetCidr string = '10.0.0.0/24'
 
-@description('Application Load Balancer subnet CIDR.')
-param albSubnetCidr string = '10.0.1.0/24'
-
-@description('deploy ALB components')
-param deployALBComponents bool = false
-
 @description('Tags to apply to all newly created resources, in the form of {"key_one":"value_one","key_two":"value_two"}')
 param Tags object = {}
 
@@ -34,8 +28,6 @@ module network 'network.bicep' = {
     networkCidr: networkCidr
     subnetCidr: subnetCidr
     location: location
-    albSubnetCidr: albSubnetCidr
-    deployAlbSubnet: deployALBComponents
     tags: Tags
   }
 }
@@ -117,4 +109,3 @@ resource roleDef 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
 output RoleDefinitionId string = roleDef.name
 output NetworkName string = network.outputs.networkName
 output SubnetName string = network.outputs.subnetName
-output ALBSubnetName string = deployALBComponents ? network.outputs.subnetName : '' 

--- a/deployments/azure/templates/init/resources.bicepparam
+++ b/deployments/azure/templates/init/resources.bicepparam
@@ -5,7 +5,5 @@ param networkCidr = [
   '10.0.0.0/16'
 ]
 param subnetCidr = '10.0.0.0/24'
-param albSubnetCidr = '10.0.1.0/24'
-param deployALBComponents = false
 param Tags = {}
 


### PR DESCRIPTION
## Description
Removed the alb portion of the resources template. This included albSubnetCidr and deployAlbSubnet params, as well as the alb subnet, and alb name, and the alb name output.

## Testing
Testing was done by deploying the updated resources template and confirming now alb params were available, and the resource group and network were deployed correctly.

![Screenshot 2024-07-12 at 1 30 40 PM](https://github.com/user-attachments/assets/4b18d01c-605a-4676-b5de-2576d60b652a)
![Screenshot 2024-07-12 at 1 32 07 PM](https://github.com/user-attachments/assets/5dfdbeb5-29b4-4fc5-acb0-da386e99ee80)
![Screenshot 2024-07-12 at 1 33 26 PM](https://github.com/user-attachments/assets/a326bf4c-50c8-4a95-a71b-e0481be1a399)
