### PR TITLE
REGULUS-1075: Security Group rules are overwritten when deploying 2 Stacks within the same Resource Group name and Security Group value on Azure

### DIFF
--- a/deployments/azure/templates/arm/ai-unlimited/ai-unlimited-with-nlb.json
+++ b/deployments/azure/templates/arm/ai-unlimited/ai-unlimited-with-nlb.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.27.1.19265",
-      "templateHash": "2147970961421321338"
+      "version": "0.28.1.47646",
+      "templateHash": "13795192631052622263"
     }
   },
   "parameters": {
@@ -225,8 +225,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "2086007890190396523"
+              "version": "0.28.1.47646",
+              "templateHash": "11956638839921274883"
             }
           },
           "parameters": {
@@ -242,13 +242,22 @@
             "tags": {
               "type": "object",
               "defaultValue": {}
+            },
+            "uuid": {
+              "type": "string",
+              "defaultValue": "[newGuid()]"
             }
+          },
+          "variables": {
+            "nameCharLimit": 24,
+            "uniqueName": "[format('{0}-{1}', parameters('keyVaultName'), uniqueString(parameters('uuid')))]",
+            "uniqueKeyVaultName": "[substring(format('{0}', variables('uniqueName')), 0, if(less(length(variables('uniqueName')), variables('nameCharLimit')), length(variables('uniqueName')), variables('nameCharLimit')))]"
           },
           "resources": [
             {
               "type": "Microsoft.KeyVault/vaults",
               "apiVersion": "2023-02-01",
-              "name": "[parameters('keyVaultName')]",
+              "name": "[variables('uniqueKeyVaultName')]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
               "properties": {
@@ -268,11 +277,11 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
+              "value": "[resourceId('Microsoft.KeyVault/vaults', variables('uniqueKeyVaultName'))]"
             },
             "name": {
               "type": "string",
-              "value": "[parameters('keyVaultName')]"
+              "value": "[variables('uniqueKeyVaultName')]"
             }
           }
         }
@@ -291,7 +300,7 @@
         "mode": "Incremental",
         "parameters": {
           "vaultName": {
-            "value": "[parameters('AiUnlimitedName')]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'vault'), '2022-09-01').outputs.name.value]"
           },
           "accessPolicy": {
             "value": {
@@ -335,8 +344,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "15097183793238578678"
+              "version": "0.28.1.47646",
+              "templateHash": "3238468818736820524"
             }
           },
           "parameters": {
@@ -362,7 +371,8 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'ai-unlimited')]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'ai-unlimited')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'vault')]"
       ]
     },
     {
@@ -413,8 +423,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "14953220464415817385"
+              "version": "0.28.1.47646",
+              "templateHash": "4929926268271391774"
             }
           },
           "parameters": {
@@ -459,13 +469,22 @@
             "tags": {
               "type": "object",
               "defaultValue": {}
+            },
+            "uuid": {
+              "type": "string",
+              "defaultValue": "[newGuid()]"
             }
+          },
+          "variables": {
+            "nameCharLimit": 60,
+            "uniqueName": "[format('{0}-{1}', parameters('name'), uniqueString(parameters('uuid')))]",
+            "uniqueSecurityGroupName": "[substring(format('{0}', variables('uniqueName')), 0, if(less(length(variables('uniqueName')), variables('nameCharLimit')), length(variables('uniqueName')), variables('nameCharLimit')))]"
           },
           "resources": [
             {
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2022-11-01",
-              "name": "[parameters('name')]",
+              "name": "[variables('uniqueSecurityGroupName')]",
               "tags": "[parameters('tags')]",
               "location": "[parameters('location')]"
             },
@@ -473,7 +492,7 @@
               "condition": "[parameters('sshAccess')]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-ssh-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-ssh-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -504,14 +523,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-workspace-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-workspace-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -542,14 +561,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedGrpcPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-workspace-grpc-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-workspace-grpc-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -580,14 +599,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('jupyterHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-juptyer-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-juptyer-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -618,14 +637,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedSchedulerHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-scheduler-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-scheduler-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -656,14 +675,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             }
           ],
           "outputs": {
             "Id": {
               "type": "string",
-              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
             }
           }
         }
@@ -708,8 +727,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "8548105070855149200"
+              "version": "0.28.1.47646",
+              "templateHash": "9026566997103330654"
             }
           },
           "parameters": {
@@ -836,8 +855,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13411721602606036822"
+                      "version": "0.28.1.47646",
+                      "templateHash": "6759154498137298299"
                     }
                   },
                   "parameters": {
@@ -918,8 +937,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13411721602606036822"
+                      "version": "0.28.1.47646",
+                      "templateHash": "6759154498137298299"
                     }
                   },
                   "parameters": {
@@ -1061,8 +1080,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "7784277815830270611"
+              "version": "0.28.1.47646",
+              "templateHash": "14119123377490335719"
             }
           },
           "parameters": {
@@ -1342,8 +1361,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13411721602606036822"
+                      "version": "0.28.1.47646",
+                      "templateHash": "6759154498137298299"
                     }
                   },
                   "parameters": {
@@ -1447,7 +1466,11 @@
       "type": "string",
       "value": "[format('ssh azureuser@{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'ai-unlimited'), '2022-09-01').outputs.PrivateIP.value)]"
     },
-    "SecurityGroup": {
+    "KeyVaultName": {
+      "type": "string",
+      "value": "[if(equals(parameters('UseKeyVault'), 'New'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'vault'), '2022-09-01').outputs.name.value, '')]"
+    },
+    "NetworkSecurityGroupId": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'firewall'), '2022-09-01').outputs.Id.value]"
     }

--- a/deployments/azure/templates/arm/ai-unlimited/ai-unlimited-without-lb.json
+++ b/deployments/azure/templates/arm/ai-unlimited/ai-unlimited-without-lb.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.27.1.19265",
-      "templateHash": "143557961565303710"
+      "version": "0.28.1.47646",
+      "templateHash": "12647146379393834850"
     }
   },
   "parameters": {
@@ -224,8 +224,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "2086007890190396523"
+              "version": "0.28.1.47646",
+              "templateHash": "11956638839921274883"
             }
           },
           "parameters": {
@@ -241,13 +241,22 @@
             "tags": {
               "type": "object",
               "defaultValue": {}
+            },
+            "uuid": {
+              "type": "string",
+              "defaultValue": "[newGuid()]"
             }
+          },
+          "variables": {
+            "nameCharLimit": 24,
+            "uniqueName": "[format('{0}-{1}', parameters('keyVaultName'), uniqueString(parameters('uuid')))]",
+            "uniqueKeyVaultName": "[substring(format('{0}', variables('uniqueName')), 0, if(less(length(variables('uniqueName')), variables('nameCharLimit')), length(variables('uniqueName')), variables('nameCharLimit')))]"
           },
           "resources": [
             {
               "type": "Microsoft.KeyVault/vaults",
               "apiVersion": "2023-02-01",
-              "name": "[parameters('keyVaultName')]",
+              "name": "[variables('uniqueKeyVaultName')]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
               "properties": {
@@ -267,11 +276,11 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
+              "value": "[resourceId('Microsoft.KeyVault/vaults', variables('uniqueKeyVaultName'))]"
             },
             "name": {
               "type": "string",
-              "value": "[parameters('keyVaultName')]"
+              "value": "[variables('uniqueKeyVaultName')]"
             }
           }
         }
@@ -290,7 +299,7 @@
         "mode": "Incremental",
         "parameters": {
           "vaultName": {
-            "value": "[parameters('AiUnlimitedName')]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'vault'), '2022-09-01').outputs.name.value]"
           },
           "accessPolicy": {
             "value": {
@@ -334,8 +343,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "15097183793238578678"
+              "version": "0.28.1.47646",
+              "templateHash": "3238468818736820524"
             }
           },
           "parameters": {
@@ -361,7 +370,8 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'ai-unlimited')]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'ai-unlimited')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'vault')]"
       ]
     },
     {
@@ -412,8 +422,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "14953220464415817385"
+              "version": "0.28.1.47646",
+              "templateHash": "4929926268271391774"
             }
           },
           "parameters": {
@@ -458,13 +468,22 @@
             "tags": {
               "type": "object",
               "defaultValue": {}
+            },
+            "uuid": {
+              "type": "string",
+              "defaultValue": "[newGuid()]"
             }
+          },
+          "variables": {
+            "nameCharLimit": 60,
+            "uniqueName": "[format('{0}-{1}', parameters('name'), uniqueString(parameters('uuid')))]",
+            "uniqueSecurityGroupName": "[substring(format('{0}', variables('uniqueName')), 0, if(less(length(variables('uniqueName')), variables('nameCharLimit')), length(variables('uniqueName')), variables('nameCharLimit')))]"
           },
           "resources": [
             {
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2022-11-01",
-              "name": "[parameters('name')]",
+              "name": "[variables('uniqueSecurityGroupName')]",
               "tags": "[parameters('tags')]",
               "location": "[parameters('location')]"
             },
@@ -472,7 +491,7 @@
               "condition": "[parameters('sshAccess')]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-ssh-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-ssh-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -503,14 +522,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-workspace-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-workspace-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -541,14 +560,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedGrpcPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-workspace-grpc-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-workspace-grpc-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -579,14 +598,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('jupyterHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-juptyer-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-juptyer-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -617,14 +636,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedSchedulerHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-scheduler-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-scheduler-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -655,14 +674,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             }
           ],
           "outputs": {
             "Id": {
               "type": "string",
-              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
             }
           }
         }
@@ -731,8 +750,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "7784277815830270611"
+              "version": "0.28.1.47646",
+              "templateHash": "14119123377490335719"
             }
           },
           "parameters": {
@@ -1012,8 +1031,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13411721602606036822"
+                      "version": "0.28.1.47646",
+                      "templateHash": "6759154498137298299"
                     }
                   },
                   "parameters": {
@@ -1116,7 +1135,11 @@
       "type": "string",
       "value": "[format('ssh azureuser@{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'ai-unlimited'), '2022-09-01').outputs.PublicIP.value)]"
     },
-    "SecurityGroup": {
+    "KeyVaultName": {
+      "type": "string",
+      "value": "[if(equals(parameters('UseKeyVault'), 'New'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'vault'), '2022-09-01').outputs.name.value, '')]"
+    },
+    "NetworkSecurityGroupId": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'firewall'), '2022-09-01').outputs.Id.value]"
     }

--- a/deployments/azure/templates/arm/init/resources.json
+++ b/deployments/azure/templates/arm/init/resources.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.27.1.19265",
-      "templateHash": "4707887880859282690"
+      "version": "0.28.1.47646",
+      "templateHash": "3755223610480160492"
     }
   },
   "parameters": {
@@ -117,7 +117,8 @@
               "Microsoft.Resources/deployments/operationStatuses/read",
               "Microsoft.Resources/deploymentStacks/read",
               "Microsoft.Resources/deploymentStacks/write",
-              "Microsoft.Resources/deploymentStacks/delete"
+              "Microsoft.Resources/deploymentStacks/delete",
+              "Microsoft.Compute/galleries/images/versions/read"
             ]
           }
         ],
@@ -162,8 +163,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "6905809493163786927"
+              "version": "0.28.1.47646",
+              "templateHash": "3893635077912970094"
             }
           },
           "parameters": {

--- a/deployments/azure/templates/arm/init/role-policy.json
+++ b/deployments/azure/templates/arm/init/role-policy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.170.59819",
-      "templateHash": "14076160163954081866"
+      "version": "0.28.1.47646",
+      "templateHash": "4093971344613406123"
     }
   },
   "parameters": {
@@ -84,7 +84,8 @@
               "Microsoft.Resources/deployments/operationStatuses/read",
               "Microsoft.Resources/deploymentStacks/read",
               "Microsoft.Resources/deploymentStacks/write",
-              "Microsoft.Resources/deploymentStacks/delete"
+              "Microsoft.Resources/deploymentStacks/delete",
+              "Microsoft.Compute/galleries/images/versions/read"
             ]
           }
         ],

--- a/deployments/azure/templates/arm/jupyter/jupyter-with-nlb.json
+++ b/deployments/azure/templates/arm/jupyter/jupyter-with-nlb.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.27.1.19265",
-      "templateHash": "17418549750365838633"
+      "version": "0.28.1.47646",
+      "templateHash": "13407002185802552800"
     }
   },
   "parameters": {
@@ -202,8 +202,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "8275252103706232855"
+              "version": "0.28.1.47646",
+              "templateHash": "4929926268271391774"
             }
           },
           "parameters": {
@@ -237,6 +237,10 @@
               "type": "int",
               "defaultValue": 0
             },
+            "aiUnlimitedSchedulerHttpPort": {
+              "type": "int",
+              "defaultValue": 0
+            },
             "jupyterHttpPort": {
               "type": "int",
               "defaultValue": 0
@@ -244,13 +248,22 @@
             "tags": {
               "type": "object",
               "defaultValue": {}
+            },
+            "uuid": {
+              "type": "string",
+              "defaultValue": "[newGuid()]"
             }
+          },
+          "variables": {
+            "nameCharLimit": 60,
+            "uniqueName": "[format('{0}-{1}', parameters('name'), uniqueString(parameters('uuid')))]",
+            "uniqueSecurityGroupName": "[substring(format('{0}', variables('uniqueName')), 0, if(less(length(variables('uniqueName')), variables('nameCharLimit')), length(variables('uniqueName')), variables('nameCharLimit')))]"
           },
           "resources": [
             {
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2022-11-01",
-              "name": "[parameters('name')]",
+              "name": "[variables('uniqueSecurityGroupName')]",
               "tags": "[parameters('tags')]",
               "location": "[parameters('location')]"
             },
@@ -258,7 +271,7 @@
               "condition": "[parameters('sshAccess')]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-ssh-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-ssh-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -289,14 +302,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-workspace-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-workspace-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -327,14 +340,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedGrpcPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-workspace-grpc-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-workspace-grpc-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -365,14 +378,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('jupyterHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-juptyer-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-juptyer-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -403,14 +416,52 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
+              ]
+            },
+            {
+              "condition": "[not(equals(parameters('aiUnlimitedSchedulerHttpPort'), 0))]",
+              "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+              "apiVersion": "2023-04-01",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-scheduler-http-allow', variables('uniqueSecurityGroupName')))]",
+              "properties": {
+                "copy": [
+                  {
+                    "name": "destinationApplicationSecurityGroups",
+                    "count": "[length(parameters('detinationAppSecGroups'))]",
+                    "input": {
+                      "id": "[parameters('detinationAppSecGroups')[copyIndex('destinationApplicationSecurityGroups')]]",
+                      "location": "[parameters('location')]"
+                    }
+                  },
+                  {
+                    "name": "sourceApplicationSecurityGroups",
+                    "count": "[length(parameters('sourceAppSecGroups'))]",
+                    "input": {
+                      "id": "[parameters('sourceAppSecGroups')[copyIndex('sourceApplicationSecurityGroups')]]",
+                      "location": "[parameters('location')]"
+                    }
+                  }
+                ],
+                "access": "Allow",
+                "description": "allow http to the scheduler instance",
+                "destinationAddressPrefix": "*",
+                "destinationPortRange": "[string(parameters('aiUnlimitedSchedulerHttpPort'))]",
+                "direction": "Inbound",
+                "priority": 704,
+                "protocol": "Tcp",
+                "sourceAddressPrefixes": "[parameters('accessCidrs')]",
+                "sourcePortRange": "*"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             }
           ],
           "outputs": {
             "Id": {
               "type": "string",
-              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
             }
           }
         }
@@ -449,8 +500,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "1313008413011978885"
+              "version": "0.28.1.47646",
+              "templateHash": "9026566997103330654"
             }
           },
           "parameters": {
@@ -468,6 +519,10 @@
               "defaultValue": 0
             },
             "aiUnlimitedGrpcPort": {
+              "type": "int",
+              "defaultValue": 0
+            },
+            "aiUnlimitedSchedulerHttpPort": {
               "type": "int",
               "defaultValue": 0
             },
@@ -516,8 +571,8 @@
                     "name": "[format('{0}OutboundBackendPool', parameters('name'))]"
                   }
                 ],
-                "loadBalancingRules": "[flatten(createArray(if(not(equals(parameters('aiUnlimitedHttpPort'), 0)), createArray(createObject('name', 'AiUnlimitedUI', 'properties', createObject('frontendIPConfiguration', createObject('id', resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', parameters('name'), format('{0}Inbound', parameters('name')))), 'backendAddressPool', createObject('id', resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('name'), format('{0}OutboundBackendPool', parameters('name')))), 'frontendPort', parameters('aiUnlimitedHttpPort'), 'backendPort', parameters('aiUnlimitedHttpPort'), 'enableFloatingIP', false(), 'idleTimeoutInMinutes', 15, 'protocol', 'Tcp', 'enableTcpReset', true(), 'loadDistribution', 'Default', 'disableOutboundSnat', true(), 'probe', createObject('id', resourceId('Microsoft.Network/loadBalancers/probes', parameters('name'), format('{0}UILbProbe', parameters('name'))))))), createArray()), if(not(equals(parameters('aiUnlimitedGrpcPort'), 0)), createArray(createObject('name', 'AiUnlimitedAPI', 'properties', createObject('frontendIPConfiguration', createObject('id', resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', parameters('name'), format('{0}Inbound', parameters('name')))), 'backendAddressPool', createObject('id', resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('name'), format('{0}OutboundBackendPool', parameters('name')))), 'frontendPort', parameters('aiUnlimitedGrpcPort'), 'backendPort', parameters('aiUnlimitedGrpcPort'), 'enableFloatingIP', false(), 'idleTimeoutInMinutes', 15, 'protocol', 'Tcp', 'enableTcpReset', true(), 'loadDistribution', 'Default', 'disableOutboundSnat', true(), 'probe', createObject('id', resourceId('Microsoft.Network/loadBalancers/probes', parameters('name'), format('{0}APILbProbe', parameters('name'))))))), createArray()), if(not(equals(parameters('jupyterHttpPort'), 0)), createArray(createObject('name', 'JupyterUI', 'properties', createObject('frontendIPConfiguration', createObject('id', resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', parameters('name'), format('{0}Inbound', parameters('name')))), 'backendAddressPool', createObject('id', resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('name'), format('{0}OutboundBackendPool', parameters('name')))), 'frontendPort', parameters('jupyterHttpPort'), 'backendPort', parameters('jupyterHttpPort'), 'enableFloatingIP', false(), 'idleTimeoutInMinutes', 15, 'protocol', 'Tcp', 'enableTcpReset', true(), 'loadDistribution', 'Default', 'disableOutboundSnat', true(), 'probe', createObject('id', resourceId('Microsoft.Network/loadBalancers/probes', parameters('name'), format('{0}JupyterLbProbe', parameters('name'))))))), createArray())))]",
-                "probes": "[flatten(createArray(if(not(equals(parameters('aiUnlimitedHttpPort'), 0)), createArray(createObject('name', format('{0}UILbProbe', parameters('name')), 'properties', createObject('protocol', 'Tcp', 'port', parameters('aiUnlimitedHttpPort'), 'intervalInSeconds', 5, 'numberOfProbes', 2))), createArray()), if(not(equals(parameters('aiUnlimitedGrpcPort'), 0)), createArray(createObject('name', format('{0}APILbProbe', parameters('name')), 'properties', createObject('protocol', 'Tcp', 'port', parameters('aiUnlimitedGrpcPort'), 'intervalInSeconds', 5, 'numberOfProbes', 2))), createArray()), if(not(equals(parameters('jupyterHttpPort'), 0)), createArray(createObject('name', format('{0}JupyterLbProbe', parameters('name')), 'properties', createObject('protocol', 'Tcp', 'port', parameters('jupyterHttpPort'), 'intervalInSeconds', 5, 'numberOfProbes', 2))), createArray())))]",
+                "loadBalancingRules": "[flatten(createArray(if(not(equals(parameters('aiUnlimitedHttpPort'), 0)), createArray(createObject('name', 'AiUnlimitedUI', 'properties', createObject('frontendIPConfiguration', createObject('id', resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', parameters('name'), format('{0}Inbound', parameters('name')))), 'backendAddressPool', createObject('id', resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('name'), format('{0}OutboundBackendPool', parameters('name')))), 'frontendPort', parameters('aiUnlimitedHttpPort'), 'backendPort', parameters('aiUnlimitedHttpPort'), 'enableFloatingIP', false(), 'idleTimeoutInMinutes', 15, 'protocol', 'Tcp', 'enableTcpReset', true(), 'loadDistribution', 'Default', 'disableOutboundSnat', true(), 'probe', createObject('id', resourceId('Microsoft.Network/loadBalancers/probes', parameters('name'), format('{0}UILbProbe', parameters('name'))))))), createArray()), if(not(equals(parameters('aiUnlimitedGrpcPort'), 0)), createArray(createObject('name', 'AiUnlimitedAPI', 'properties', createObject('frontendIPConfiguration', createObject('id', resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', parameters('name'), format('{0}Inbound', parameters('name')))), 'backendAddressPool', createObject('id', resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('name'), format('{0}OutboundBackendPool', parameters('name')))), 'frontendPort', parameters('aiUnlimitedGrpcPort'), 'backendPort', parameters('aiUnlimitedGrpcPort'), 'enableFloatingIP', false(), 'idleTimeoutInMinutes', 15, 'protocol', 'Tcp', 'enableTcpReset', true(), 'loadDistribution', 'Default', 'disableOutboundSnat', true(), 'probe', createObject('id', resourceId('Microsoft.Network/loadBalancers/probes', parameters('name'), format('{0}APILbProbe', parameters('name'))))))), createArray()), if(not(equals(parameters('jupyterHttpPort'), 0)), createArray(createObject('name', 'JupyterUI', 'properties', createObject('frontendIPConfiguration', createObject('id', resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', parameters('name'), format('{0}Inbound', parameters('name')))), 'backendAddressPool', createObject('id', resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('name'), format('{0}OutboundBackendPool', parameters('name')))), 'frontendPort', parameters('jupyterHttpPort'), 'backendPort', parameters('jupyterHttpPort'), 'enableFloatingIP', false(), 'idleTimeoutInMinutes', 15, 'protocol', 'Tcp', 'enableTcpReset', true(), 'loadDistribution', 'Default', 'disableOutboundSnat', true(), 'probe', createObject('id', resourceId('Microsoft.Network/loadBalancers/probes', parameters('name'), format('{0}JupyterLbProbe', parameters('name'))))))), createArray()), if(not(equals(parameters('aiUnlimitedSchedulerHttpPort'), 0)), createArray(createObject('name', 'AiUnlimitedSchedulerHttp', 'properties', createObject('frontendIPConfiguration', createObject('id', resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', parameters('name'), format('{0}Inbound', parameters('name')))), 'backendAddressPool', createObject('id', resourceId('Microsoft.Network/loadBalancers/backendAddressPools', parameters('name'), format('{0}OutboundBackendPool', parameters('name')))), 'frontendPort', parameters('aiUnlimitedSchedulerHttpPort'), 'backendPort', parameters('aiUnlimitedSchedulerHttpPort'), 'enableFloatingIP', false(), 'idleTimeoutInMinutes', 15, 'protocol', 'Tcp', 'enableTcpReset', true(), 'loadDistribution', 'Default', 'disableOutboundSnat', true(), 'probe', createObject('id', resourceId('Microsoft.Network/loadBalancers/probes', parameters('name'), format('{0}SchedulerHttpLbProbe', parameters('name'))))))), createArray())))]",
+                "probes": "[flatten(createArray(if(not(equals(parameters('aiUnlimitedHttpPort'), 0)), createArray(createObject('name', format('{0}UILbProbe', parameters('name')), 'properties', createObject('protocol', 'Tcp', 'port', parameters('aiUnlimitedHttpPort'), 'intervalInSeconds', 5, 'numberOfProbes', 2))), createArray()), if(not(equals(parameters('aiUnlimitedGrpcPort'), 0)), createArray(createObject('name', format('{0}APILbProbe', parameters('name')), 'properties', createObject('protocol', 'Tcp', 'port', parameters('aiUnlimitedGrpcPort'), 'intervalInSeconds', 5, 'numberOfProbes', 2))), createArray()), if(not(equals(parameters('jupyterHttpPort'), 0)), createArray(createObject('name', format('{0}JupyterLbProbe', parameters('name')), 'properties', createObject('protocol', 'Tcp', 'port', parameters('jupyterHttpPort'), 'intervalInSeconds', 5, 'numberOfProbes', 2))), createArray()), if(not(equals(parameters('aiUnlimitedSchedulerHttpPort'), 0)), createArray(createObject('name', format('{0}SchedulerHttpLbProbe', parameters('name')), 'properties', createObject('protocol', 'Http', 'port', parameters('aiUnlimitedSchedulerHttpPort'), 'requestPath', '/healthcheck', 'intervalInSeconds', 5, 'numberOfProbes', 2))), createArray())))]",
                 "outboundRules": [
                   {
                     "name": "myOutboundRule",
@@ -573,8 +628,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13411721602606036822"
+                      "version": "0.28.1.47646",
+                      "templateHash": "6759154498137298299"
                     }
                   },
                   "parameters": {
@@ -655,8 +710,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13411721602606036822"
+                      "version": "0.28.1.47646",
+                      "templateHash": "6759154498137298299"
                     }
                   },
                   "parameters": {
@@ -798,8 +853,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "7784277815830270611"
+              "version": "0.28.1.47646",
+              "templateHash": "14119123377490335719"
             }
           },
           "parameters": {
@@ -1079,8 +1134,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13411721602606036822"
+                      "version": "0.28.1.47646",
+                      "templateHash": "6759154498137298299"
                     }
                   },
                   "parameters": {
@@ -1176,7 +1231,7 @@
       "type": "string",
       "value": "[format('ssh azureuser@{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'jupyter'), '2022-09-01').outputs.PrivateIP.value)]"
     },
-    "SecurityGroup": {
+    "NetworkSecurityGroupId": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'firewall'), '2022-09-01').outputs.Id.value]"
     }

--- a/deployments/azure/templates/arm/jupyter/jupyter-without-lb.json
+++ b/deployments/azure/templates/arm/jupyter/jupyter-without-lb.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.27.1.19265",
-      "templateHash": "3264134040675753697"
+      "version": "0.28.1.47646",
+      "templateHash": "8452004607038960062"
     }
   },
   "parameters": {
@@ -200,8 +200,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "8275252103706232855"
+              "version": "0.28.1.47646",
+              "templateHash": "4929926268271391774"
             }
           },
           "parameters": {
@@ -235,6 +235,10 @@
               "type": "int",
               "defaultValue": 0
             },
+            "aiUnlimitedSchedulerHttpPort": {
+              "type": "int",
+              "defaultValue": 0
+            },
             "jupyterHttpPort": {
               "type": "int",
               "defaultValue": 0
@@ -242,13 +246,22 @@
             "tags": {
               "type": "object",
               "defaultValue": {}
+            },
+            "uuid": {
+              "type": "string",
+              "defaultValue": "[newGuid()]"
             }
+          },
+          "variables": {
+            "nameCharLimit": 60,
+            "uniqueName": "[format('{0}-{1}', parameters('name'), uniqueString(parameters('uuid')))]",
+            "uniqueSecurityGroupName": "[substring(format('{0}', variables('uniqueName')), 0, if(less(length(variables('uniqueName')), variables('nameCharLimit')), length(variables('uniqueName')), variables('nameCharLimit')))]"
           },
           "resources": [
             {
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2022-11-01",
-              "name": "[parameters('name')]",
+              "name": "[variables('uniqueSecurityGroupName')]",
               "tags": "[parameters('tags')]",
               "location": "[parameters('location')]"
             },
@@ -256,7 +269,7 @@
               "condition": "[parameters('sshAccess')]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-ssh-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-ssh-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -287,14 +300,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-workspace-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-workspace-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -325,14 +338,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('aiUnlimitedGrpcPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-workspace-grpc-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-workspace-grpc-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -363,14 +376,14 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             },
             {
               "condition": "[not(equals(parameters('jupyterHttpPort'), 0))]",
               "type": "Microsoft.Network/networkSecurityGroups/securityRules",
               "apiVersion": "2023-04-01",
-              "name": "[format('{0}/{1}', parameters('name'), format('{0}-juptyer-http-allow', parameters('name')))]",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-juptyer-http-allow', variables('uniqueSecurityGroupName')))]",
               "properties": {
                 "copy": [
                   {
@@ -401,14 +414,52 @@
                 "sourcePortRange": "*"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
+              ]
+            },
+            {
+              "condition": "[not(equals(parameters('aiUnlimitedSchedulerHttpPort'), 0))]",
+              "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+              "apiVersion": "2023-04-01",
+              "name": "[format('{0}/{1}', variables('uniqueSecurityGroupName'), format('{0}-scheduler-http-allow', variables('uniqueSecurityGroupName')))]",
+              "properties": {
+                "copy": [
+                  {
+                    "name": "destinationApplicationSecurityGroups",
+                    "count": "[length(parameters('detinationAppSecGroups'))]",
+                    "input": {
+                      "id": "[parameters('detinationAppSecGroups')[copyIndex('destinationApplicationSecurityGroups')]]",
+                      "location": "[parameters('location')]"
+                    }
+                  },
+                  {
+                    "name": "sourceApplicationSecurityGroups",
+                    "count": "[length(parameters('sourceAppSecGroups'))]",
+                    "input": {
+                      "id": "[parameters('sourceAppSecGroups')[copyIndex('sourceApplicationSecurityGroups')]]",
+                      "location": "[parameters('location')]"
+                    }
+                  }
+                ],
+                "access": "Allow",
+                "description": "allow http to the scheduler instance",
+                "destinationAddressPrefix": "*",
+                "destinationPortRange": "[string(parameters('aiUnlimitedSchedulerHttpPort'))]",
+                "direction": "Inbound",
+                "priority": 704,
+                "protocol": "Tcp",
+                "sourceAddressPrefixes": "[parameters('accessCidrs')]",
+                "sourcePortRange": "*"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
               ]
             }
           ],
           "outputs": {
             "Id": {
               "type": "string",
-              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('name'))]"
+              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('uniqueSecurityGroupName'))]"
             }
           }
         }
@@ -477,8 +528,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.27.1.19265",
-              "templateHash": "7784277815830270611"
+              "version": "0.28.1.47646",
+              "templateHash": "14119123377490335719"
             }
           },
           "parameters": {
@@ -758,8 +809,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.27.1.19265",
-                      "templateHash": "13411721602606036822"
+                      "version": "0.28.1.47646",
+                      "templateHash": "6759154498137298299"
                     }
                   },
                   "parameters": {
@@ -854,7 +905,7 @@
       "type": "string",
       "value": "[format('ssh azureuser@{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'jupyter'), '2022-09-01').outputs.PublicIP.value)]"
     },
-    "SecurityGroup": {
+    "NetworkSecurityGroupId": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'firewall'), '2022-09-01').outputs.Id.value]"
     }

--- a/deployments/azure/templates/bicep/ai-unlimited/ai-unlimited-without-lb.bicep
+++ b/deployments/azure/templates/bicep/ai-unlimited/ai-unlimited-without-lb.bicep
@@ -88,34 +88,28 @@ var registry = 'teradata'
 var workspaceRepository = 'ai-unlimited-workspaces'
 var workspaceSchedulerRepository = 'ai-unlimited-scheduler'
 
-var cloudInitData = base64(
-  format(
-    loadTextContent('../../../scripts/ai-unlimited.cloudinit.yaml'),
-    base64(
-      format(
-        loadTextContent('../../../scripts/ai-unlimited.service'),
-        registry,
-        workspaceRepository,
-        AiUnlimitedVersion,
-        AiUnlimitedHttpPort,
-        AiUnlimitedGrpcPort,
-        subscription().subscriptionId,
-        subscription().tenantId,
-        '--network-alias ai-unlimited'
-      )
-    ),
-    base64(
-      format(
-        loadTextContent('../../../scripts/ai-unlimited-scheduler.service'),
-        registry,
-        workspaceSchedulerRepository,
-        AiUnlimitedSchedulerVersion,
-        // AiUnlimitedSchedulerGrpcPort,
-        AiUnlimitedSchedulerHttpPort
-      )
-    )
-  )
-)
+var cloudInitData = base64(format(
+  loadTextContent('../../../scripts/ai-unlimited.cloudinit.yaml'),
+  base64(format(
+    loadTextContent('../../../scripts/ai-unlimited.service'),
+    registry,
+    workspaceRepository,
+    AiUnlimitedVersion,
+    AiUnlimitedHttpPort,
+    AiUnlimitedGrpcPort,
+    subscription().subscriptionId,
+    subscription().tenantId,
+    '--network-alias ai-unlimited'
+  )),
+  base64(format(
+    loadTextContent('../../../scripts/ai-unlimited-scheduler.service'),
+    registry,
+    workspaceSchedulerRepository,
+    AiUnlimitedSchedulerVersion,
+    // AiUnlimitedSchedulerGrpcPort,
+    AiUnlimitedSchedulerHttpPort
+  ))
+))
 
 resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' existing = {
   name: ResourceGroupName
@@ -146,7 +140,7 @@ module vaultAccessPolicy '../modules/vault/access-policy.bicep' = if (UseKeyVaul
   scope: rg
   name: 'vault-access-policy'
   params: {
-    vaultName: AiUnlimitedName
+    vaultName: vault.outputs.name
     accessPolicy: {
       tenantId: subscription().tenantId
       objectId: aiUnlimited.outputs.PrincipleId
@@ -231,4 +225,5 @@ output AiUnlimitedPrivateHttpAccess string = 'http://${aiUnlimited.outputs.Priva
 output AiUnlimitedPublicGrpcAccess string = 'http://${aiUnlimited.outputs.PublicIP}:${AiUnlimitedGrpcPort}'
 output AiUnlimitedPrivateGrpcAccess string = 'http://${aiUnlimited.outputs.PrivateIP}:${AiUnlimitedGrpcPort}'
 output sshCommand string = 'ssh azureuser@${aiUnlimited.outputs.PublicIP}'
-output SecurityGroup string = firewall.outputs.Id
+output KeyVaultName string = (UseKeyVault == 'New') ? vault.outputs.name : ''
+output NetworkSecurityGroupId string = firewall.outputs.Id

--- a/deployments/azure/templates/bicep/jupyter/jupyter-with-nlb.bicep
+++ b/deployments/azure/templates/bicep/jupyter/jupyter-with-nlb.bicep
@@ -155,4 +155,4 @@ output PrivateIP string = jupyter.outputs.PrivateIP
 output JupyterLabPublicHttpAccess string = 'http://${nlb.outputs.PublicDns}:${JupyterHttpPort}?token=${JupyterToken}'
 output JupyterLabPrivateHttpAccess string = 'http://${jupyter.outputs.PrivateIP}:${JupyterHttpPort}?token=${JupyterToken}'
 output sshCommand string = 'ssh azureuser@${jupyter.outputs.PrivateIP}'
-output SecurityGroup string = firewall.outputs.Id
+output NetworkSecurityGroupId string = firewall.outputs.Id

--- a/deployments/azure/templates/bicep/jupyter/jupyter-without-lb.bicep
+++ b/deployments/azure/templates/bicep/jupyter/jupyter-without-lb.bicep
@@ -139,4 +139,4 @@ output PrivateIP string = jupyter.outputs.PrivateIP
 output JupyterLabPublicHttpAccess string = 'http://${jupyter.outputs.PublicIP}:${JupyterHttpPort}?token=${JupyterToken}'
 output JupyterLabPrivateHttpAccess string = 'http://${jupyter.outputs.PrivateIP}:${JupyterHttpPort}?token=${JupyterToken}'
 output sshCommand string = 'ssh azureuser@${jupyter.outputs.PublicIP}'
-output SecurityGroup string = firewall.outputs.Id
+output NetworkSecurityGroupId string = firewall.outputs.Id

--- a/deployments/azure/templates/bicep/modules/firewall.bicep
+++ b/deployments/azure/templates/bicep/modules/firewall.bicep
@@ -11,42 +11,53 @@ param aiUnlimitedSchedulerHttpPort int = 0
 // param aiUnlimitedSchedulerGrpcPort int = 0
 param jupyterHttpPort int = 0
 param tags object = {}
+param uuid string = newGuid()
+
+var nameCharLimit = 60
+var uniqueName = '${name}-${uniqueString(uuid)}'
+var uniqueSecurityGroupName = substring(
+  '${uniqueName}',
+  0,
+  length(uniqueName) < nameCharLimit ? length(uniqueName) : nameCharLimit
+)
 
 resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2022-11-01' = {
-  name: name
+  name: uniqueSecurityGroupName
   tags: tags
   location: location
 }
 
 resource sshAllow 'Microsoft.Network/networkSecurityGroups/securityRules@2023-04-01' = if (sshAccess) {
-  name: '${name}-ssh-allow'
+  name: '${uniqueSecurityGroupName}-ssh-allow'
   parent: networkSecurityGroup
 
   properties: {
     access: 'Allow'
     description: 'allow ssh to the workspace instance'
     destinationAddressPrefix: '*' // destinationAddressPrefixes: []
-    destinationApplicationSecurityGroups: [for secgroup in detinationAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    destinationApplicationSecurityGroups: [
+      for secgroup in detinationAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     destinationPortRange: '22' // destinationPortRanges: []
     direction: 'Inbound'
     priority: 700
     protocol: 'Tcp'
     sourceAddressPrefixes: accessCidrs // sourceAddressPrefix: 'string'
-    sourceApplicationSecurityGroups: [for secgroup in sourceAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    sourceApplicationSecurityGroups: [
+      for secgroup in sourceAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     sourcePortRange: '*' // sourcePortRanges: []
   }
 }
 
 // resource sshDeny 'Microsoft.Network/networkSecurityGroups/securityRules@2023-04-01' = if (!sshAccess) {
-//   name: '${name}-ssh-deny'
+//   name: '${uniqueSecurityGroupName}-ssh-deny'
 //   parent: networkSecurityGroup
 
 //   properties: {
@@ -63,115 +74,123 @@ resource sshAllow 'Microsoft.Network/networkSecurityGroups/securityRules@2023-04
 // }
 
 resource AiUnlimitedHTTP 'Microsoft.Network/networkSecurityGroups/securityRules@2023-04-01' = if (aiUnlimitedHttpPort != 0) {
-  name: '${name}-workspace-http-allow'
+  name: '${uniqueSecurityGroupName}-workspace-http-allow'
   parent: networkSecurityGroup
 
   properties: {
     access: 'Allow'
     description: 'allow http to the workspace instance'
     destinationAddressPrefix: '*' // destinationAddressPrefixes: []
-    destinationApplicationSecurityGroups: [for secgroup in detinationAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    destinationApplicationSecurityGroups: [
+      for secgroup in detinationAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     destinationPortRange: string(aiUnlimitedHttpPort) // destinationPortRanges: []
     direction: 'Inbound'
     priority: 701
     protocol: 'Tcp'
     sourceAddressPrefixes: accessCidrs // sourceAddressPrefix: 'string'
-    sourceApplicationSecurityGroups: [for secgroup in sourceAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    sourceApplicationSecurityGroups: [
+      for secgroup in sourceAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     sourcePortRange: '*' // sourcePortRanges: []
   }
 }
 
 resource AiUnlimitedGRPC 'Microsoft.Network/networkSecurityGroups/securityRules@2023-04-01' = if (aiUnlimitedGrpcPort != 0) {
-  name: '${name}-workspace-grpc-allow'
+  name: '${uniqueSecurityGroupName}-workspace-grpc-allow'
   parent: networkSecurityGroup
 
   properties: {
     access: 'Allow'
     description: 'allow grpc to the workspace instance'
     destinationAddressPrefix: '*' // destinationAddressPrefixes: []
-    destinationApplicationSecurityGroups: [for secgroup in detinationAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    destinationApplicationSecurityGroups: [
+      for secgroup in detinationAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     destinationPortRange: string(aiUnlimitedGrpcPort) // destinationPortRanges: []
     direction: 'Inbound'
     priority: 702
     protocol: 'Tcp'
     sourceAddressPrefixes: accessCidrs // sourceAddressPrefix: 'string'
-    sourceApplicationSecurityGroups: [for secgroup in sourceAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    sourceApplicationSecurityGroups: [
+      for secgroup in sourceAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     sourcePortRange: '*' // sourcePortRanges: []
   }
 }
 
 resource JupyterHTTP 'Microsoft.Network/networkSecurityGroups/securityRules@2023-04-01' = if (jupyterHttpPort != 0) {
-  name: '${name}-juptyer-http-allow'
+  name: '${uniqueSecurityGroupName}-juptyer-http-allow'
   parent: networkSecurityGroup
 
   properties: {
     access: 'Allow'
     description: 'allow http to the jupyter instance'
     destinationAddressPrefix: '*' // destinationAddressPrefixes: []
-    destinationApplicationSecurityGroups: [for secgroup in detinationAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    destinationApplicationSecurityGroups: [
+      for secgroup in detinationAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     destinationPortRange: string(jupyterHttpPort) // destinationPortRanges: []
     direction: 'Inbound'
     priority: 703
     protocol: 'Tcp'
     sourceAddressPrefixes: accessCidrs // sourceAddressPrefix: 'string'
-    sourceApplicationSecurityGroups: [for secgroup in sourceAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    sourceApplicationSecurityGroups: [
+      for secgroup in sourceAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     sourcePortRange: '*' // sourcePortRanges: []
   }
 }
 
 resource AiUnlimitedSchedulerHTTP 'Microsoft.Network/networkSecurityGroups/securityRules@2023-04-01' = if (aiUnlimitedSchedulerHttpPort != 0) {
-  name: '${name}-scheduler-http-allow'
+  name: '${uniqueSecurityGroupName}-scheduler-http-allow'
   parent: networkSecurityGroup
 
   properties: {
     access: 'Allow'
     description: 'allow http to the scheduler instance'
     destinationAddressPrefix: '*' // destinationAddressPrefixes: []
-    destinationApplicationSecurityGroups: [for secgroup in detinationAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    destinationApplicationSecurityGroups: [
+      for secgroup in detinationAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     destinationPortRange: string(aiUnlimitedSchedulerHttpPort) // destinationPortRanges: []
     direction: 'Inbound'
     priority: 704
     protocol: 'Tcp'
     sourceAddressPrefixes: accessCidrs // sourceAddressPrefix: 'string'
-    sourceApplicationSecurityGroups: [for secgroup in sourceAppSecGroups: {
-      id: secgroup
-      location: location
-    }
+    sourceApplicationSecurityGroups: [
+      for secgroup in sourceAppSecGroups: {
+        id: secgroup
+        location: location
+      }
     ]
     sourcePortRange: '*' // sourcePortRanges: []
   }
 }
 
 // resource AiUnlimitedSchedulerGRPC 'Microsoft.Network/networkSecurityGroups/securityRules@2023-04-01' = if (aiUnlimitedSchedulerGrpcPort != 0) {
-//   name: '${name}-scheduler-grpc-allow'
+//   name: '${uniqueSecurityGroupName}-scheduler-grpc-allow'
 //   parent: networkSecurityGroup
 
 //   properties: {

--- a/deployments/azure/templates/bicep/modules/vault/vault.bicep
+++ b/deployments/azure/templates/bicep/modules/vault/vault.bicep
@@ -2,10 +2,20 @@ param encryptVolumes bool
 param keyVaultName string
 param location string
 param tags object = {}
+param uuid string = newGuid()
+
+var nameCharLimit = 24
+var uniqueName = '${keyVaultName}-${uniqueString(uuid)}'
+var uniqueKeyVaultName = substring(
+  '${uniqueName}',
+  0,
+  length(uniqueName) < nameCharLimit ? length(uniqueName) : nameCharLimit
+)
+
 
 resource vault 'Microsoft.KeyVault/vaults@2023-02-01' = {
   location: location
-  name: keyVaultName
+  name: uniqueKeyVaultName
   tags: tags
   properties: {
     sku: {

--- a/deployments/azure/templates/init/resources.bicep
+++ b/deployments/azure/templates/init/resources.bicep
@@ -97,6 +97,7 @@ resource roleDef 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.Resources/deploymentStacks/read'
           'Microsoft.Resources/deploymentStacks/write'
           'Microsoft.Resources/deploymentStacks/delete'
+          'Microsoft.Compute/galleries/images/versions/read'
         ]
       }
     ]

--- a/deployments/azure/templates/init/role-policy.bicep
+++ b/deployments/azure/templates/init/role-policy.bicep
@@ -68,6 +68,7 @@ resource roleDef 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.Resources/deploymentStacks/read'
           'Microsoft.Resources/deploymentStacks/write'
           'Microsoft.Resources/deploymentStacks/delete'
+          'Microsoft.Compute/galleries/images/versions/read'
         ]
       }
     ]


### PR DESCRIPTION
### Changes
* made network security group name unique by using uuid
* made key vault unique by using uuid
* add permissions to role policy + resources to read image versions (to pull dev image versions for testing)
* add `KeyVaultName` to arm templates outputs to use for workspace deployments
* update `SecurityGroup` output to `NetworkSecurityGroupId` in arm templates for clarity

### Testing
* With NLB:
<img width="1792" alt="Screenshot 2024-07-17 at 5 01 02 PM" src="https://github.com/user-attachments/assets/9b7b310b-a39e-4828-9885-6e9f5526199b">

* Without LB:
<img width="1792" alt="Screenshot 2024-07-17 at 5 42 55 PM" src="https://github.com/user-attachments/assets/5157b995-ad4e-4447-a8fe-87d1ab968b55">

* Same name + uuid network security groups
<img width="1207" alt="Screenshot 2024-07-17 at 2 07 11 PM" src="https://github.com/user-attachments/assets/12dcd40b-ec7e-4243-8dd6-d5b6eccbc086">

