### PR TITLE
Fix Security Group and *LB issues on AWS

### DIFF
--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-alb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-alb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template AI Unlimited: AI Unlimited is a instance based service for deploying and suspending clusters of AI Unlimited compute engines, and managing project lifecycles.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -35,9 +35,9 @@ Metadata:
           - AiUnlimitedHttpPort
           - AiUnlimitedGrpcPort
           - AiUnlimitedVersion
-
-          # - AiUnlimitedSchedulerVersion
-          # - AiUnlimitedSchedulerPort
+          - AiUnlimitedSchedulerVersion
+          - AiUnlimitedSchedulerHttpPort
+          - AiUnlimitedSchedulerGrpcPort
       - Label:
           default: Persistent volume
         Parameters:
@@ -125,13 +125,22 @@ Parameters:
     MinValue: 0
     MaxValue: 65535
 
-  # AiUnlimitedSchedulerPort:
-  #   Description: port to access the AI Unlimited Scheduler API.
-  #   Type: Number
-  #   Default: 50051
-  #   ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-  #   MinValue: 0
-  #   MaxValue: 65535
+  AiUnlimitedSchedulerHttpPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50061
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
+  AiUnlimitedSchedulerGrpcPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50051
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
   AiUnlimitedGrpcPort:
     Description: port to access the AI Unlimited API.
     Type: Number
@@ -145,10 +154,11 @@ Parameters:
     Type: String
     Default: latest
 
-  # AiUnlimitedSchedulerVersion:
-  #   Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
-  #   Type: String
-  #   Default: latest
+  AiUnlimitedSchedulerVersion:
+    Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
+    Type: String
+    Default: latest
+
   RootVolumeSize:
     Description: size of the root disk to the AI Unlimited server.
     Type: Number
@@ -330,6 +340,10 @@ Conditions:
     - !Equals
       - !Ref SecurityGroup
       - ""
+
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
 
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
@@ -522,8 +536,8 @@ Resources:
                 ExecStartPre=/usr/bin/docker pull teradata/ai-unlimited-scheduler:latest
                 ExecStart=/usr/bin/docker run \
                     --network ai_unlimited \
-                    -p 50051:50051 \
-                    -p 50061:50061 \
+                    -p ${ AiUnlimitedSchedulerGrpcPort }:50051 \
+                    -p ${ AiUnlimitedSchedulerHttpPort }:50061 \
                     -v /etc/td/ai-unlimited:/etc/td \
                     -e TD_WSSCHED_LOG_PATH=/etc/td/workspaces/scheduler_logs \
                     -e TD_WSSCHED_TASK_LOG_PATH=/etc/td/workspaces/scheduler_logs/projects \
@@ -610,10 +624,6 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
         - FromPort: !Ref AiUnlimitedGrpcPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedGrpcPort
@@ -625,13 +635,9 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
-        - FromPort: 50061
+        - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
-          ToPort: 50061
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -640,13 +646,9 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
-        - FromPort: 50051
+        - FromPort: !Ref AiUnlimitedSchedulerGrpcPort
           IpProtocol: tcp
-          ToPort: 50051
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -655,11 +657,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLISTORSECGROUP
+    Condition: HASCIDRORPREFIXLIST
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -703,18 +701,23 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref AiUnlimitedSchedulerHTTPTargetGroup
       LoadBalancerArn: !Ref LoadBalancer
-      Port: 50061
-      Protocol: HTTP
+      Port: !Ref AiUnlimitedSchedulerHttpPort
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref ACMCertificate
 
-  # AiUnlimitedSchedulerGRPCListener:
-  #   Type: AWS::ElasticLoadBalancingV2::Listener
-  #   Properties:
-  #     DefaultActions:
-  #       - Type: forward
-  #         TargetGroupArn: !Ref AiUnlimitedSchedulerGRPCTargetGroup
-  #     LoadBalancerArn: !Ref LoadBalancer
-  #     Port: 50051
-  #     Protocol: HTTP
+  AiUnlimitedSchedulerGRPCListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref AiUnlimitedSchedulerGRPCTargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: !Ref AiUnlimitedSchedulerGrpcPort
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref ACMCertificate
+
   AiUnlimitedHTTPTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -816,8 +819,8 @@ Resources:
           - aisch
           - ui
           - http
-      Port: 50061
-      Protocol: HTTP
+      Port: !Ref AiUnlimitedSchedulerHttpPort
+      Protocol: HTTPS
       TargetGroupAttributes:
         - Key: stickiness.enabled
           Value: true
@@ -829,47 +832,48 @@ Resources:
           Value: "20"
       Targets:
         - Id: !Ref AiUnlimitedServer
-          Port: 50061
+          Port: !Ref AiUnlimitedSchedulerHttpPort
       VpcId: !Ref Vpc
 
-  # AiUnlimitedSchedulerGRPCTargetGroup:
-  #   Type: AWS::ElasticLoadBalancingV2::TargetGroup
-  #   Properties:
-  #     HealthCheckIntervalSeconds: 30
-  #     HealthCheckProtocol: HTTPS
-  #     HealthCheckTimeoutSeconds: 15
-  #     Matcher:
-  #       GrpcCode: "0"
-  #     Name: !Join
-  #       - "-"
-  #       - - !Select
-  #           - 4
-  #           - !Split
-  #             - "-"
-  #             - !Select
-  #               - 2
-  #               - !Split
-  #                 - /
-  #                 - !Ref AWS::StackId
-  #         - aisch
-  #         - api
-  #         - grpc
-  #     Port: 50051
-  #     Protocol: HTTPS
-  #     ProtocolVersion: GRPC
-  #     TargetGroupAttributes:
-  #       - Key: stickiness.enabled
-  #         Value: true
-  #       - Key: stickiness.type
-  #         Value: app_cookie
-  #       - Key: stickiness.app_cookie.cookie_name
-  #         Value: TDWUNLIMITEDHTTPSSESSION
-  #       - Key: deregistration_delay.timeout_seconds
-  #         Value: "20"
-  #     Targets:
-  #       - Id: !Ref AiUnlimitedServer
-  #         Port: 50051
-  #     VpcId: !Ref Vpc
+  AiUnlimitedSchedulerGRPCTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckProtocol: HTTPS
+      HealthCheckTimeoutSeconds: 15
+      Matcher:
+        GrpcCode: "0"
+      Name: !Join
+        - "-"
+        - - !Select
+            - 4
+            - !Split
+              - "-"
+              - !Select
+                - 2
+                - !Split
+                  - /
+                  - !Ref AWS::StackId
+          - aisch
+          - api
+          - grpc
+      Port: !Ref AiUnlimitedSchedulerGrpcPort
+      Protocol: HTTPS
+      ProtocolVersion: GRPC
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: app_cookie
+        - Key: stickiness.app_cookie.cookie_name
+          Value: TDWUNLIMITEDHTTPSSESSION
+        - Key: deregistration_delay.timeout_seconds
+          Value: "20"
+      Targets:
+        - Id: !Ref AiUnlimitedServer
+          Port: !Ref AiUnlimitedSchedulerGrpcPort
+      VpcId: !Ref Vpc
+
   AiUnlimitedSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -885,13 +889,41 @@ Resources:
           ToPort: !Ref AiUnlimitedGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
         - IpProtocol: tcp
-          FromPort: 50061
-          ToPort: 50061
+          FromPort: !Ref AiUnlimitedSchedulerHttpPort
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
         - IpProtocol: tcp
-          FromPort: 50051
-          ToPort: 50051
+          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedHttpPort
+            ToPort: !Ref AiUnlimitedHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedGrpcPort
+            ToPort: !Ref AiUnlimitedGrpcPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedSchedulerHttpPort
+            ToPort: !Ref AiUnlimitedSchedulerHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+            ToPort: !Ref AiUnlimitedSchedulerGrpcPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -1155,9 +1187,13 @@ Outputs:
     Description: Loadbalancer access endpoint for AI Unlimited API Access
     Value: !Sub ${ DnsName }:${ AiUnlimitedGrpcPort }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: AI Unlimited Security Group
     Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+
+  LoadBalancerSecurityGroup:
+    Description: AI Unlimited Load Balancer Security Group
+    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
 
   PublicSshConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-alb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-alb.yaml
@@ -567,6 +567,11 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
+            - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -607,7 +612,7 @@ Resources:
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource AiUnlimitedServer --configsets ai_unlimited_install --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource AiUnlimitedServer --region ${AWS::Region}
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerAiUnlimitedSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref Vpc
@@ -624,6 +629,10 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
         - FromPort: !Ref AiUnlimitedGrpcPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedGrpcPort
@@ -635,6 +644,18 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
+
+  LoadBalancerSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server from LoadBalancer over http, grpc, and ssh
+      SecurityGroupIngress:
         - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedSchedulerHttpPort
@@ -657,7 +678,11 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLIST
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -667,7 +692,8 @@ Resources:
         - !Ref LoadBalancerSubnetOne
         - !Ref LoadBalancerSubnetTwo
       SecurityGroups:
-        - !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
       Type: application
 
   AiUnlimitedHTTPListener:
@@ -883,19 +909,11 @@ Resources:
         - IpProtocol: tcp
           FromPort: !Ref AiUnlimitedHttpPort
           ToPort: !Ref AiUnlimitedHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - IpProtocol: tcp
           FromPort: !Ref AiUnlimitedGrpcPort
           ToPort: !Ref AiUnlimitedGrpcPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - IpProtocol: tcp
-          FromPort: !Ref AiUnlimitedSchedulerHttpPort
-          ToPort: !Ref AiUnlimitedSchedulerHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - IpProtocol: tcp
-          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
-          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
@@ -910,6 +928,21 @@ Resources:
             ToPort: !Ref AiUnlimitedGrpcPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
+
+  AiUnlimitedSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server over http and grpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - IpProtocol: tcp
+          FromPort: !Ref AiUnlimitedSchedulerHttpPort
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
@@ -1187,13 +1220,23 @@ Outputs:
     Description: Loadbalancer access endpoint for AI Unlimited API Access
     Value: !Sub ${ DnsName }:${ AiUnlimitedGrpcPort }
 
-  InstanceSecurityGroup:
+  InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+    Value: !Join 
+      - ', '
+      - - !GetAtt AiUnlimitedSecurityGroup.GroupId
+        - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
+    Value: !Join 
+      - ', '
+      - - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
 
   PublicSshConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-alb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-alb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template AI Unlimited: AI Unlimited is a instance based service for deploying and suspending clusters of AI Unlimited compute engines, and managing project lifecycles.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -629,7 +629,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -644,7 +644,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -678,7 +678,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -870,11 +870,11 @@ Resources:
       Matcher:
         GrpcCode: "0"
       Name: !Join
-        - "-"
+        - '-'
         - - !Select
             - 4
             - !Split
-              - "-"
+              - '-'
               - !Select
                 - 2
                 - !Split
@@ -914,14 +914,14 @@ Resources:
           FromPort: !Ref AiUnlimitedGrpcPort
           ToPort: !Ref AiUnlimitedGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedHttpPort
             ToPort: !Ref AiUnlimitedHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedGrpcPort
@@ -943,14 +943,14 @@ Resources:
           FromPort: !Ref AiUnlimitedSchedulerHttpPort
           ToPort: !Ref AiUnlimitedSchedulerHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerHttpPort
             ToPort: !Ref AiUnlimitedSchedulerHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerGrpcPort
@@ -1222,7 +1222,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt AiUnlimitedSecurityGroup.GroupId
         - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
@@ -1233,7 +1233,7 @@ Outputs:
 
   LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -552,6 +552,11 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
+            - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -592,7 +597,7 @@ Resources:
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource AiUnlimitedServer --configsets ai_unlimited_install --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource AiUnlimitedServer --region ${AWS::Region}
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerAiUnlimitedSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref Vpc
@@ -620,9 +625,21 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-        - FromPort: 50051
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
+
+  LoadBalancerSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server from LoadBalancer over http, grpc, and ssh
+      SecurityGroupIngress:
+        - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
-          ToPort: 50051
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -631,9 +648,9 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-        - FromPort: 50061
+        - FromPort: !Ref AiUnlimitedSchedulerGrpcPort
           IpProtocol: tcp
-          ToPort: 50061
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -642,7 +659,11 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLIST
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -651,7 +672,8 @@ Resources:
       Subnets:
         - !Ref LoadBalancerSubnet
       SecurityGroups:
-        - !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
       Type: network
 
   AiUnlimitedHTTPListener:
@@ -839,24 +861,16 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref Vpc
-      GroupDescription: Enable access to  AI Unlimited server over http and grpc
+      GroupDescription: Enable access to AI Unlimited server over http and grpc
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: !Ref AiUnlimitedHttpPort
           ToPort: !Ref AiUnlimitedHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - IpProtocol: tcp
           FromPort: !Ref AiUnlimitedGrpcPort
           ToPort: !Ref AiUnlimitedGrpcPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - IpProtocol: tcp
-          FromPort: !Ref AiUnlimitedSchedulerHttpPort
-          ToPort: !Ref AiUnlimitedSchedulerHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - IpProtocol: tcp
-          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
-          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
@@ -871,6 +885,21 @@ Resources:
             ToPort: !Ref AiUnlimitedGrpcPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
+
+  AiUnlimitedSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server over http and grpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - IpProtocol: tcp
+          FromPort: !Ref AiUnlimitedSchedulerHttpPort
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
@@ -881,8 +910,8 @@ Resources:
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
-            FromPort: !Ref AiUnlimitedSchedulerGRPCTargetGroup
-            ToPort: !Ref AiUnlimitedSchedulerGRPCTargetGroup
+            FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+            ToPort: !Ref AiUnlimitedScheduleGrpcPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
 
@@ -1130,13 +1159,23 @@ Outputs:
     Description: Loadbalancer access endpoint for AI Unlimited API Access
     Value: !Sub ${ LoadBalancer.DNSName }:${ AiUnlimitedGrpcPort }
 
-  InstanceSecurityGroup:
-    Description: AI Unlimited Security Group
-    Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+  InstanceSecurityGroups:
+    Description: AI Unlimited Security Groups
+    Value: !Join 
+      - ', '
+      - - !GetAtt AiUnlimitedSecurityGroup.GroupId
+        - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
+    Value: !Join 
+      - ', '
+      - - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
 
   PublicSSHConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template AI Unlimited: AI Unlimited is a instance based service for deploying and suspending clusters of AI Unlimited compute engines, and managing project lifecycles.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -32,9 +32,9 @@ Metadata:
           - AiUnlimitedHttpPort
           - AiUnlimitedGrpcPort
           - AiUnlimitedVersion
-
-          # - AiUnlimitedSchedulerVersion
-          # - AiUnlimitedSchedulerPort
+          - AiUnlimitedSchedulerVersion
+          - AiUnlimitedSchedulerHttpPort
+          - AiUnlimitedSchedulerGrpcPort
       - Label:
           default: Persistent volume
         Parameters:
@@ -109,13 +109,22 @@ Parameters:
     MinValue: 0
     MaxValue: 65535
 
-  # AiUnlimitedSchedulerPort:
-  #   Description: port to access the AI Unlimited Scheduler API.
-  #   Type: Number
-  #   Default: 50051
-  #   ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-  #   MinValue: 0
-  #   MaxValue: 65535
+  AiUnlimitedSchedulerHttpPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50061
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
+  AiUnlimitedSchedulerGrpcPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50051
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
   AiUnlimitedGrpcPort:
     Description: port to access the AI Unlimited API.
     Type: Number
@@ -129,10 +138,11 @@ Parameters:
     Type: String
     Default: latest
 
-  # AiUnlimitedSchedulerVersion:
-  #   Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
-  #   Type: String
-  #   Default: latest
+  AiUnlimitedSchedulerVersion:
+    Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
+    Type: String
+    Default: latest
+
   RootVolumeSize:
     Description: size of the root disk to the AI Unlimited server.
     Type: Number
@@ -314,6 +324,10 @@ Conditions:
     - !Equals
       - !Ref SecurityGroup
       - ""
+
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
 
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
@@ -507,8 +521,8 @@ Resources:
                 ExecStartPre=/usr/bin/docker pull teradata/ai-unlimited-scheduler:latest
                 ExecStart=/usr/bin/docker run \
                     --network ai_unlimited \
-                    -p 50051:50051 \
-                    -p 50061:50061 \
+                    -p ${ AiUnlimitedSchedulerGrpcPort }:50051 \
+                    -p ${ AiUnlimitedSchedulerHttpPort }:50061 \
                     -v /etc/td/ai-unlimited:/etc/td \
                     -e TD_WSSCHED_LOG_PATH=/etc/td/workspaces/scheduler_logs \
                     -e TD_WSSCHED_TASK_LOG_PATH=/etc/td/workspaces/scheduler_logs/projects \
@@ -595,10 +609,6 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
         - FromPort: !Ref AiUnlimitedGrpcPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedGrpcPort
@@ -609,10 +619,6 @@ Resources:
           SourcePrefixListId: !If
             - HASPREFIXLIST
             - !Ref PrefixList
-            - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
             - !Ref AWS::NoValue
         - FromPort: 50051
           IpProtocol: tcp
@@ -625,10 +631,6 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
         - FromPort: 50061
           IpProtocol: tcp
           ToPort: 50061
@@ -640,11 +642,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLISTORSECGROUP
+    Condition: HASCIDRORPREFIXLIST
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -683,18 +681,19 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref AiUnlimitedSchedulerHTTPTargetGroup
       LoadBalancerArn: !Ref LoadBalancer
-      Port: 50061
+      Port: !Ref AiUnlimitedSchedulerHttpPort
       Protocol: TCP
 
-  # AiUnlimitedSchedulerGRPCListener:
-  #   Type: AWS::ElasticLoadBalancingV2::Listener
-  #   Properties:
-  #     DefaultActions:
-  #       - Type: forward
-  #         TargetGroupArn: !Ref AiUnlimitedSchedulerGRPCTargetGroup
-  #     LoadBalancerArn: !Ref LoadBalancer
-  #     Port: 50051
-  #     Protocol: TCP
+  AiUnlimitedSchedulerGRPCListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref AiUnlimitedSchedulerGRPCTargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: !Ref AiUnlimitedSchedulerGrpcPort
+      Protocol: TCP
+
   AiUnlimitedHTTPTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -787,7 +786,7 @@ Resources:
           - aisch
           - ui
           - http
-      Port: 50061
+      Port: !Ref AiUnlimitedSchedulerHttpPort
       Protocol: TCP
       TargetGroupAttributes:
         - Key: stickiness.enabled
@@ -798,43 +797,44 @@ Resources:
           Value: "20"
       Targets:
         - Id: !Ref AiUnlimitedServer
-          Port: 50061
+          Port: !Ref AiUnlimitedSchedulerHttpPort
       VpcId: !Ref Vpc
 
-  # AiUnlimitedSchedulerGRPCTargetGroup:
-  #   Type: AWS::ElasticLoadBalancingV2::TargetGroup
-  #   Properties:
-  #     HealthCheckIntervalSeconds: 30
-  #     HealthCheckProtocol: TCP
-  #     HealthCheckTimeoutSeconds: 15
-  #     HealthyThresholdCount: 5
-  #     Name: !Join
-  #       - "-"
-  #       - - !Select
-  #           - 4
-  #           - !Split
-  #             - "-"
-  #             - !Select
-  #               - 2
-  #               - !Split
-  #                 - /
-  #                 - !Ref AWS::StackId
-  #         - td-aisch
-  #         - api
-  #         - grpc
-  #     Port: 50051
-  #     Protocol: TCP
-  #     TargetGroupAttributes:
-  #       - Key: stickiness.enabled
-  #         Value: true
-  #       - Key: stickiness.type
-  #         Value: source_ip
-  #       - Key: deregistration_delay.timeout_seconds
-  #         Value: "20"
-  #     Targets:
-  #       - Id: !Ref AiUnlimitedServer
-  #         Port: 50051
-  #     VpcId: !Ref Vpc
+  AiUnlimitedSchedulerGRPCTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 15
+      HealthyThresholdCount: 5
+      Name: !Join
+        - "-"
+        - - !Select
+            - 4
+            - !Split
+              - "-"
+              - !Select
+                - 2
+                - !Split
+                  - /
+                  - !Ref AWS::StackId
+          - td-aisch
+          - api
+          - grpc
+      Port: !Ref AiUnlimitedSchedulerGrpcPort
+      Protocol: TCP
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: source_ip
+        - Key: deregistration_delay.timeout_seconds
+          Value: "20"
+      Targets:
+        - Id: !Ref AiUnlimitedServer
+          Port: !Ref AiUnlimitedSchedulerGrpcPort
+      VpcId: !Ref Vpc
+
   AiUnlimitedSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -850,13 +850,41 @@ Resources:
           ToPort: !Ref AiUnlimitedGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
         - IpProtocol: tcp
-          FromPort: 50061
-          ToPort: 50061
+          FromPort: !Ref AiUnlimitedSchedulerHttpPort
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
         - IpProtocol: tcp
-          FromPort: 50051
-          ToPort: 50051
+          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedHttpPort
+            ToPort: !Ref AiUnlimitedHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedGrpcPort
+            ToPort: !Ref AiUnlimitedGrpcPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedSchedulerHttpPort
+            ToPort: !Ref AiUnlimitedSchedulerHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedSchedulerGRPCTargetGroup
+            ToPort: !Ref AiUnlimitedSchedulerGRPCTargetGroup
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -1102,9 +1130,13 @@ Outputs:
     Description: Loadbalancer access endpoint for AI Unlimited API Access
     Value: !Sub ${ LoadBalancer.DNSName }:${ AiUnlimitedGrpcPort }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: AI Unlimited Security Group
     Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+
+  LoadBalancerSecurityGroup:
+    Description: AI Unlimited Load Balancer Security Group
+    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
 
   PublicSSHConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -828,7 +828,6 @@ Resources:
       HealthCheckIntervalSeconds: 30
       HealthCheckProtocol: TCP
       HealthCheckTimeoutSeconds: 15
-      HealthyThresholdCount: 5
       Name: !Join
         - '-'
         - - !Select
@@ -840,7 +839,7 @@ Resources:
                 - !Split
                   - /
                   - !Ref AWS::StackId
-          - td-aisch
+          - aisch
           - api
           - grpc
       Port: !Ref AiUnlimitedSchedulerGrpcPort
@@ -911,7 +910,7 @@ Resources:
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerGrpcPort
-            ToPort: !Ref AiUnlimitedScheduleGrpcPort
+            ToPort: !Ref AiUnlimitedSchedulerGrpcPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
 

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template AI Unlimited: AI Unlimited is a instance based service for deploying and suspending clusters of AI Unlimited compute engines, and managing project lifecycles.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -625,7 +625,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -659,7 +659,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -830,11 +830,11 @@ Resources:
       HealthCheckTimeoutSeconds: 15
       HealthyThresholdCount: 5
       Name: !Join
-        - "-"
+        - '-'
         - - !Select
             - 4
             - !Split
-              - "-"
+              - '-'
               - !Select
                 - 2
                 - !Split
@@ -871,14 +871,14 @@ Resources:
           FromPort: !Ref AiUnlimitedGrpcPort
           ToPort: !Ref AiUnlimitedGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedHttpPort
             ToPort: !Ref AiUnlimitedHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedGrpcPort
@@ -900,14 +900,14 @@ Resources:
           FromPort: !Ref AiUnlimitedSchedulerHttpPort
           ToPort: !Ref AiUnlimitedSchedulerHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerHttpPort
             ToPort: !Ref AiUnlimitedSchedulerHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerGrpcPort
@@ -1161,7 +1161,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Groups
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt AiUnlimitedSecurityGroup.GroupId
         - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
@@ -1172,7 +1172,7 @@ Outputs:
 
   LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template AI Unlimited: AI Unlimited is a instance based service for deploying and suspending clusters of AI Unlimited compute engines, and managing project lifecycles.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -30,9 +30,9 @@ Metadata:
           - AiUnlimitedHttpPort
           - AiUnlimitedGrpcPort
           - AiUnlimitedVersion
-
-          # - AiUnlimitedSchedulerVersion
-          # - AiUnlimitedSchedulerPort
+          - AiUnlimitedSchedulerVersion
+          - AiUnlimitedSchedulerHttpPort
+          - AiUnlimitedSchedulerGrpcPort
       - Label:
           default: Persistent volume
         Parameters:
@@ -102,22 +102,32 @@ Parameters:
     MinValue: 0
     MaxValue: 65535
 
-  # AiUnlimitedSchedulerPort:
-  #   Description: port to access the AI Unlimited Scheduler API.
-  #   Type: Number
-  #   Default: 50051
-  #   ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-  #   MinValue: 0
-  #   MaxValue: 65535
+  AiUnlimitedSchedulerHttpPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50061
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
+  AiUnlimitedSchedulerGrpcPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50051
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
   AiUnlimitedVersion:
     Description: Which version of AI Unlimited to deploy, uses container version tags, defaults to "latest"
     Type: String
     Default: latest
 
-  # AiUnlimitedSchedulerVersion:
-  #   Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
-  #   Type: String
-  #   Default: latest
+  AiUnlimitedSchedulerVersion:
+    Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
+    Type: String
+    Default: latest
+
   RootVolumeSize:
     Description: size of the root disk to the AI Unlimited server.
     Type: Number
@@ -299,6 +309,10 @@ Conditions:
     - !Equals
       - !Ref SecurityGroup
       - ""
+
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
 
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
@@ -492,8 +506,8 @@ Resources:
                 ExecStartPre=/usr/bin/docker pull teradata/ai-unlimited-scheduler:latest
                 ExecStart=/usr/bin/docker run \
                     --network ai_unlimited \
-                    -p 50051:50051 \
-                    -p 50061:50061 \
+                    -p ${ AiUnlimitedSchedulerGrpcPort }:50051 \
+                    -p ${ AiUnlimitedSchedulerHttpPort }:50061 \
                     -v /etc/td/ai-unlimited:/etc/td \
                     -e TD_WSSCHED_LOG_PATH=/etc/td/workspaces/scheduler_logs \
                     -e TD_WSSCHED_TASK_LOG_PATH=/etc/td/workspaces/scheduler_logs/projects \
@@ -592,9 +606,9 @@ Resources:
             - HASCIDR
             - !Ref AccessCIDR
             - !Ref AWS::NoValue
-        - FromPort: 50051
+        - FromPort: !Ref AiUnlimitedSchedulerGrpcPort
           IpProtocol: tcp
-          ToPort: 50051
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -607,9 +621,9 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
-        - FromPort: 50061
+        - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
-          ToPort: 50061
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -875,7 +889,7 @@ Outputs:
     Description: Teradata AI Unlimited private API Access
     Value: !Sub http://${AiUnlimitedServer.PrivateDnsName}:${ AiUnlimitedGrpcPort }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: AI Unlimited Security Group
     Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
 

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -538,6 +538,11 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
+            - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -606,13 +611,6 @@ Resources:
             - HASCIDR
             - !Ref AccessCIDR
             - !Ref AWS::NoValue
-        - FromPort: !Ref AiUnlimitedSchedulerGrpcPort
-          IpProtocol: tcp
-          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
-          CidrIp: !If
-            - HASCIDR
-            - !Ref AccessCIDR
-            - !Ref AWS::NoValue
           SourcePrefixListId: !If
             - HASPREFIXLIST
             - !Ref PrefixList
@@ -621,6 +619,13 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
+
+  AiUnlimitedSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server over http and grpc
+      SecurityGroupIngress:
         - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedSchedulerHttpPort
@@ -636,7 +641,21 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLISTORSECGROUP
+        - FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          IpProtocol: tcp
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -889,9 +908,16 @@ Outputs:
     Description: Teradata AI Unlimited private API Access
     Value: !Sub http://${AiUnlimitedServer.PrivateDnsName}:${ AiUnlimitedGrpcPort }
 
-  InstanceSecurityGroup:
+  InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+    Value: !Join 
+      - ', '
+      - - !GetAtt AiUnlimitedSecurityGroup.GroupId
+        - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
   PublicSSHConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template AI Unlimited: AI Unlimited is a instance based service for deploying and suspending clusters of AI Unlimited compute engines, and managing project lifecycles.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -910,7 +910,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt AiUnlimitedSecurityGroup.GroupId
         - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId

--- a/deployments/aws/templates/all-in-one/all-in-one-with-alb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-alb.yaml
@@ -626,6 +626,12 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
+            - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+            - !GetAtt JupyterSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -666,7 +672,7 @@ Resources:
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource AiUnlimitedServer --configsets ai_unlimited_install --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource AiUnlimitedServer --region ${AWS::Region}
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerAiUnlimitedSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref Vpc
@@ -683,6 +689,10 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
         - FromPort: !Ref AiUnlimitedGrpcPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedGrpcPort
@@ -694,9 +704,21 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-        - FromPort: 50061
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
+
+  LoadBalancerSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server from LoadBalancer over http, grpc, and ssh
+      SecurityGroupIngress:
+        - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
-          ToPort: 50061
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -705,6 +727,29 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
+        - FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          IpProtocol: tcp
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
+
+  LoadBalancerJupyterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server from LoadBalancer over http, grpc, and ssh
+      SecurityGroupIngress:
         - FromPort: !Ref JupyterHttpPort
           IpProtocol: tcp
           ToPort: !Ref JupyterHttpPort
@@ -716,7 +761,11 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLIST
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -726,7 +775,9 @@ Resources:
         - !Ref LoadBalancerSubnetOne
         - !Ref LoadBalancerSubnetTwo
       SecurityGroups:
-        - !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
       Type: application
 
   AiUnlimitedHTTPListener:
@@ -776,16 +827,6 @@ Resources:
       Protocol: HTTPS
       Certificates:
         - CertificateArn: !Ref ACMCertificate
-
-  AiUnlimitedSchedulerHTTPListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref AiUnlimitedSchedulerHTTPTargetGroup
-      LoadBalancerArn: !Ref LoadBalancer
-      Port: 50061
-      Protocol: HTTP
 
   AiUnlimitedSchedulerHTTPTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -990,23 +1031,11 @@ Resources:
         - IpProtocol: tcp
           FromPort: !Ref AiUnlimitedHttpPort
           ToPort: !Ref AiUnlimitedHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - IpProtocol: tcp
           FromPort: !Ref AiUnlimitedGrpcPort
           ToPort: !Ref AiUnlimitedGrpcPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - IpProtocol: tcp
-          FromPort: !Ref JupyterHttpPort
-          ToPort: !Ref JupyterHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - IpProtocol: tcp
-          FromPort: !Ref AiUnlimitedSchedulerHttpPort
-          ToPort: !Ref AiUnlimitedSchedulerHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - IpProtocol: tcp
-          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
-          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
@@ -1021,20 +1050,61 @@ Resources:
             ToPort: !Ref AiUnlimitedGrpcPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If
+
+  AiUnlimitedSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server over http and grpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - IpProtocol: tcp
+          FromPort: !Ref AiUnlimitedSchedulerHttpPort
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
-            FromPort: !Ref JupyterHttpPort
-            ToPort: !Ref JupyterHttpPort
+            FromPort: !Ref AiUnlimitedSchedulerHttpPort
+            ToPort: !Ref AiUnlimitedSchedulerHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
-            FromPort: 50061
-            ToPort: 50061
+            FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+            ToPort: !Ref AiUnlimitedSchedulerGrpcPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
+
+  JupyterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to jupyter server over http
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref JupyterHttpPort
+          ToPort: !Ref JupyterHttpPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
+        - FromPort: !Ref JupyterHttpPort
+          IpProtocol: tcp
+          ToPort: !Ref JupyterHttpPort
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -1300,13 +1370,25 @@ Outputs:
     Description: Loadbalancer access endpoint for AI Unlimited API Access
     Value: !Sub ${ DnsName }:${ AiUnlimitedGrpcPort }
 
-  InstanceSecurityGroup:
+  InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+    Value: !Join 
+      - ', '
+      - - !GetAtt AiUnlimitedSecurityGroup.GroupId
+        - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+        - !GetAtt JupyterSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
+    Value: !Join 
+      - ', '
+      - - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
 
   PublicSshConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/all-in-one/all-in-one-with-alb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-alb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template with AI Unlimited with Jupyter: AI Unlimited is a instance based service for deploying and suspending ai-unlimited clusters, and managing project lifecycles. This template also includes a Jupyter Lab service running on the same host, suitable for demonstration environments.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -35,9 +35,9 @@ Metadata:
           - AiUnlimitedHttpPort
           - AiUnlimitedGrpcPort
           - AiUnlimitedVersion
-
-          # - AiUnlimitedSchedulerVersion
-          # - AiUnlimitedSchedulerPort
+          - AiUnlimitedSchedulerVersion
+          - AiUnlimitedSchedulerHttpPort
+          - AiUnlimitedSchedulerGrpcPort
       - Label:
           default: Persistent volume
         Parameters:
@@ -147,22 +147,32 @@ Parameters:
     MinValue: 0
     MaxValue: 65535
 
-  # AiUnlimitedSchedulerPort:
-  #   Description: port to access the AI Unlimited Scheduler API.
-  #   Type: Number
-  #   Default: 50051
-  #   ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-  #   MinValue: 0
-  #   MaxValue: 65535
+  AiUnlimitedSchedulerHttpPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50061
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
+  AiUnlimitedSchedulerGrpcPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50051
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
   AiUnlimitedVersion:
     Description: Which version of AI Unlimited to deploy, uses container version tags, defaults to "latest"
     Type: String
     Default: latest
 
-  # AiUnlimitedSchedulerVersion:
-  #   Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
-  #   Type: String
-  #   Default: latest
+  AiUnlimitedSchedulerVersion:
+    Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
+    Type: String
+    Default: latest
+
   JupyterHttpPort:
     Description: port to access the Jupyter UI.
     Type: Number
@@ -346,6 +356,10 @@ Conditions:
     - !Equals
       - !Ref SecurityGroup
       - ""
+
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
 
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
@@ -541,8 +555,8 @@ Resources:
                 ExecStartPre=/usr/bin/docker pull teradata/ai-unlimited-scheduler:latest
                 ExecStart=/usr/bin/docker run \
                     --network ai_unlimited \
-                    -p 50051:50051 \
-                    -p 50061:50061 \
+                    -p ${ AiUnlimitedSchedulerGrpcPort }:50051 \
+                    -p ${ AiUnlimitedSchedulerHttpPort }:50061 \
                     -v /etc/td/ai-unlimited:/etc/td \
                     -e TD_WSSCHED_LOG_PATH=/etc/td/workspaces/scheduler_logs \
                     -e TD_WSSCHED_TASK_LOG_PATH=/etc/td/workspaces/scheduler_logs/projects \
@@ -669,10 +683,6 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
         - FromPort: !Ref AiUnlimitedGrpcPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedGrpcPort
@@ -683,10 +693,6 @@ Resources:
           SourcePrefixListId: !If
             - HASPREFIXLIST
             - !Ref PrefixList
-            - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
             - !Ref AWS::NoValue
         - FromPort: 50061
           IpProtocol: tcp
@@ -699,10 +705,6 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
         - FromPort: !Ref JupyterHttpPort
           IpProtocol: tcp
           ToPort: !Ref JupyterHttpPort
@@ -714,11 +716,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLISTORSECGROUP
+    Condition: HASCIDRORPREFIXLIST
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -755,14 +753,26 @@ Resources:
       Certificates:
         - CertificateArn: !Ref ACMCertificate
 
-  AiUnlimitedGRPCListener:
+  AiUnlimitedSchedulerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
         - Type: forward
-          TargetGroupArn: !Ref AiUnlimitedGRPCTargetGroup
+          TargetGroupArn: !Ref AiUnlimitedSchedulerHTTPTargetGroup
       LoadBalancerArn: !Ref LoadBalancer
-      Port: !Ref AiUnlimitedGrpcPort
+      Port: !Ref AiUnlimitedSchedulerHttpPort
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref ACMCertificate
+
+  AiUnlimitedSchedulerGRPCListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref AiUnlimitedSchedulerGRPCTargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: !Ref AiUnlimitedSchedulerGrpcPort
       Protocol: HTTPS
       Certificates:
         - CertificateArn: !Ref ACMCertificate
@@ -781,7 +791,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 30
-      HealthCheckProtocol: HTTP
+      HealthCheckProtocol: HTTPS
       HealthCheckTimeoutSeconds: 15
       HealthCheckPath: /healthcheck
       Matcher:
@@ -800,7 +810,7 @@ Resources:
           - aisch
           - ui
           - http
-      Port: 50061
+      Port: !Ref AiUnlimitedSchedulerHttpPort
       Protocol: HTTP
       TargetGroupAttributes:
         - Key: stickiness.enabled
@@ -813,7 +823,46 @@ Resources:
           Value: "20"
       Targets:
         - Id: !Ref AiUnlimitedServer
-          Port: 50061
+          Port: !Ref AiUnlimitedSchedulerHttpPort
+      VpcId: !Ref Vpc
+
+  AiUnlimitedSchedulerGRPCTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckProtocol: HTTPS
+      HealthCheckTimeoutSeconds: 15
+      Matcher:
+        GrpcCode: "0"
+      Name: !Join
+        - "-"
+        - - !Select
+            - 4
+            - !Split
+              - "-"
+              - !Select
+                - 2
+                - !Split
+                  - /
+                  - !Ref AWS::StackId
+          - aisch
+          - api
+          - grpc
+      Port: !Ref AiUnlimitedSchedulerGrpcPort
+      Protocol: HTTPS
+      ProtocolVersion: GRPC
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: app_cookie
+        - Key: stickiness.app_cookie.cookie_name
+          Value: TDWUNLIMITEDHTTPSSESSION
+        - Key: deregistration_delay.timeout_seconds
+          Value: "20"
+      Targets:
+        - Id: !Ref AiUnlimitedServer
+          Port: !Ref AiUnlimitedSchedulerGrpcPort
       VpcId: !Ref Vpc
 
   AiUnlimitedHTTPTargetGroup:
@@ -951,13 +1000,41 @@ Resources:
           ToPort: !Ref JupyterHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
         - IpProtocol: tcp
-          FromPort: 50061
-          ToPort: 50061
+          FromPort: !Ref AiUnlimitedSchedulerHttpPort
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
         - IpProtocol: tcp
-          FromPort: 50051
-          ToPort: 50051
+          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedHttpPort
+            ToPort: !Ref AiUnlimitedHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedGrpcPort
+            ToPort: !Ref AiUnlimitedGrpcPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref JupyterHttpPort
+            ToPort: !Ref JupyterHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: 50061
+            ToPort: 50061
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -1223,9 +1300,13 @@ Outputs:
     Description: Loadbalancer access endpoint for AI Unlimited API Access
     Value: !Sub ${ DnsName }:${ AiUnlimitedGrpcPort }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: AI Unlimited Security Group
     Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+
+  LoadBalancerSecurityGroup:
+    Description: AI Unlimited Load Balancer Security Group
+    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
 
   PublicSshConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/all-in-one/all-in-one-with-alb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-alb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template with AI Unlimited with Jupyter: AI Unlimited is a instance based service for deploying and suspending ai-unlimited clusters, and managing project lifecycles. This template also includes a Jupyter Lab service running on the same host, suitable for demonstration environments.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -689,7 +689,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -704,7 +704,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -738,7 +738,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -761,7 +761,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -876,11 +876,11 @@ Resources:
       Matcher:
         GrpcCode: "0"
       Name: !Join
-        - "-"
+        - '-'
         - - !Select
             - 4
             - !Split
-              - "-"
+              - '-'
               - !Select
                 - 2
                 - !Split
@@ -1036,14 +1036,14 @@ Resources:
           FromPort: !Ref AiUnlimitedGrpcPort
           ToPort: !Ref AiUnlimitedGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedHttpPort
             ToPort: !Ref AiUnlimitedHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedGrpcPort
@@ -1065,14 +1065,14 @@ Resources:
           FromPort: !Ref AiUnlimitedSchedulerHttpPort
           ToPort: !Ref AiUnlimitedSchedulerHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerHttpPort
             ToPort: !Ref AiUnlimitedSchedulerHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerGrpcPort
@@ -1372,7 +1372,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt AiUnlimitedSecurityGroup.GroupId
         - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
@@ -1384,7 +1384,7 @@ Outputs:
 
   LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -610,6 +610,12 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
+            - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+            - !GetAtt JupyterSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -650,7 +656,7 @@ Resources:
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource AiUnlimitedServer --configsets ai_unlimited_install --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource AiUnlimitedServer --region ${AWS::Region}
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerAiUnlimitedSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref Vpc
@@ -678,17 +684,18 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-        - FromPort: !Ref JupyterHttpPort
-          IpProtocol: tcp
-          ToPort: !Ref JupyterHttpPort
-          CidrIp: !If
-            - HASCIDR
-            - !Ref AccessCIDR
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
             - !Ref AWS::NoValue
-          SourcePrefixListId: !If
-            - HASPREFIXLIST
-            - !Ref PrefixList
-            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
+
+  LoadBalancerSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server from LoadBalancer over http, grpc, and ssh
+      SecurityGroupIngress:
         - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedSchedulerHttpPort
@@ -711,7 +718,34 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLIST
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
+
+  LoadBalancerJupyterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server from LoadBalancer over http, grpc, and ssh
+      SecurityGroupIngress:
+        - FromPort: !Ref JupyterHttpPort
+          IpProtocol: tcp
+          ToPort: !Ref JupyterHttpPort
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -720,7 +754,9 @@ Resources:
       Subnets:
         - !Ref LoadBalancerSubnet
       SecurityGroups:
-        - !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
       Type: network
 
   AiUnlimitedHTTPListener:
@@ -751,7 +787,7 @@ Resources:
           TargetGroupArn: !Ref AiUnlimitedSchedulerHTTPTargetGroup
       LoadBalancerArn: !Ref LoadBalancer
       Port: !Ref AiUnlimitedSchedulerHttpPort
-      Protocol: HTTP
+      Protocol: TCP
 
   AiUnlimitedSchedulerGRPCListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -761,7 +797,7 @@ Resources:
           TargetGroupArn: !Ref AiUnlimitedSchedulerGRPCTargetGroup
       LoadBalancerArn: !Ref LoadBalancer
       Port: !Ref AiUnlimitedSchedulerGrpcPort
-      Protocol: HTTP
+      Protocol: TCP
 
   AiUnlimitedGRPCListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -916,7 +952,7 @@ Resources:
           Value: "20"
       Targets:
         - Id: !Ref AiUnlimitedServer
-          Port: !ref AiUnlimitedSchedulerGrpcPort
+          Port: !Ref AiUnlimitedSchedulerGrpcPort
       VpcId: !Ref Vpc
 
   AiUnlimitedGRPCTargetGroup:
@@ -963,15 +999,11 @@ Resources:
         - IpProtocol: tcp
           FromPort: !Ref AiUnlimitedHttpPort
           ToPort: !Ref AiUnlimitedHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - IpProtocol: tcp
           FromPort: !Ref AiUnlimitedGrpcPort
           ToPort: !Ref AiUnlimitedGrpcPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - IpProtocol: tcp
-          FromPort: !Ref JupyterHttpPort
-          ToPort: !Ref JupyterHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
@@ -986,6 +1018,21 @@ Resources:
             ToPort: !Ref AiUnlimitedGrpcPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
+
+  AiUnlimitedSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server over http and grpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - IpProtocol: tcp
+          FromPort: !Ref AiUnlimitedSchedulerHttpPort
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
         - !If 
           - HASSECURITYGROUP
           - IpProtocol: tcp
@@ -1000,6 +1047,32 @@ Resources:
             ToPort: !Ref AiUnlimitedSchedulerHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
+
+  JupyterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to jupyter server over http
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref JupyterHttpPort
+          ToPort: !Ref JupyterHttpPort
+          SourceSecurityGroupId: !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
+        - FromPort: !Ref JupyterHttpPort
+          IpProtocol: tcp
+          ToPort: !Ref JupyterHttpPort
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -1245,13 +1318,25 @@ Outputs:
     Description: Loadbalancer access endpoint for AI Unlimited API Access
     Value: !Sub ${ LoadBalancer.DNSName }:${ AiUnlimitedGrpcPort }
 
-  InstanceSecurityGroup:
-    Description: AI Unlimited Security Group
-    Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+  InstanceSecurityGroups:
+    Description: AI Unlimited Security Groups
+    Value: !Join 
+      - ', '
+      - - !GetAtt AiUnlimitedSecurityGroup.GroupId
+        - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+        - !GetAtt JupyterSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
+    Value: !Join 
+      - ', '
+      - - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
 
   PublicSSHConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template with AI Unlimited with Jupyter: AI Unlimited is a instance based service for deploying and suspending ai-unlimited clusters, and managing project lifecycles. This template also includes a Jupyter Lab service running on the same host, suitable for demonstration environments.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -684,7 +684,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -718,7 +718,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -741,7 +741,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -925,11 +925,11 @@ Resources:
       Matcher:
         GrpcCode: "0"
       Name: !Join
-        - "-"
+        - '-'
         - - !Select
             - 4
             - !Split
-              - "-"
+              - '-'
               - !Select
                 - 2
                 - !Split
@@ -1004,14 +1004,14 @@ Resources:
           FromPort: !Ref AiUnlimitedGrpcPort
           ToPort: !Ref AiUnlimitedGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedHttpPort
             ToPort: !Ref AiUnlimitedHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedGrpcPort
@@ -1033,14 +1033,14 @@ Resources:
           FromPort: !Ref AiUnlimitedSchedulerHttpPort
           ToPort: !Ref AiUnlimitedSchedulerHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerHttpPort
             ToPort: !Ref AiUnlimitedSchedulerHttpPort
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref AiUnlimitedSchedulerGrpcPort
@@ -1320,7 +1320,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Groups
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt AiUnlimitedSecurityGroup.GroupId
         - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
@@ -1332,7 +1332,7 @@ Outputs:
 
   LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !GetAtt LoadBalancerSchedulerSecurityGroup.GroupId

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -959,7 +959,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 30
-      HealthCheckProtocol: HTTP
+      HealthCheckProtocol: TCP
       HealthCheckTimeoutSeconds: 15
       HealthyThresholdCount: 5
       Name: !Join

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -920,8 +920,6 @@ Resources:
       HealthCheckIntervalSeconds: 30
       HealthCheckProtocol: TCP
       HealthCheckTimeoutSeconds: 15
-      Matcher:
-        GrpcCode: "0"
       Name: !Join
         - '-'
         - - !Select

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -906,9 +906,7 @@ Resources:
         - Key: stickiness.enabled
           Value: true
         - Key: stickiness.type
-          Value: app_cookie
-        - Key: stickiness.app_cookie.cookie_name
-          Value: TDWUNLIMITEDHTTPSSESSION
+          Value: source_ip
         - Key: deregistration_delay.timeout_seconds
           Value: "20"
       Targets:
@@ -940,14 +938,11 @@ Resources:
           - grpc
       Port: !Ref AiUnlimitedSchedulerGrpcPort
       Protocol: TCP
-      ProtocolVersion: GRPC
       TargetGroupAttributes:
         - Key: stickiness.enabled
           Value: true
         - Key: stickiness.type
-          Value: app_cookie
-        - Key: stickiness.app_cookie.cookie_name
-          Value: TDWUNLIMITEDHTTPSSESSION
+          Value: source_ip
         - Key: deregistration_delay.timeout_seconds
           Value: "20"
       Targets:

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template with AI Unlimited with Jupyter: AI Unlimited is a instance based service for deploying and suspending ai-unlimited clusters, and managing project lifecycles. This template also includes a Jupyter Lab service running on the same host, suitable for demonstration environments.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -33,7 +33,8 @@ Metadata:
           - AiUnlimitedGrpcPort
           - AiUnlimitedVersion
           - AiUnlimitedSchedulerVersion
-          - AiUnlimitedSchedulerPort
+          - AiUnlimitedSchedulerHttpPort
+          - AiUnlimitedSchedulerGrpcPort
       - Label:
           default: Persistent volume
         Parameters:
@@ -130,7 +131,15 @@ Parameters:
     MinValue: 0
     MaxValue: 65535
 
-  AiUnlimitedSchedulerPort:
+  AiUnlimitedSchedulerHttpPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50061
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
+  AiUnlimitedSchedulerGrpcPort:
     Description: port to access the AI Unlimited Scheduler API.
     Type: Number
     Default: 50051
@@ -332,6 +341,10 @@ Conditions:
       - !Ref SecurityGroup
       - ""
 
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
+
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
     - !Condition HASPREFIXLIST
@@ -526,7 +539,8 @@ Resources:
                 ExecStartPre=/usr/bin/docker pull teradata/ai-unlimited-scheduler:${ AiUnlimitedSchedulerVersion }
                 ExecStart=/usr/bin/docker run \
                     --network ai_unlimited \
-                    -p ${ AiUnlimitedSchedulerPort }:50051 \
+                    -p ${ AiUnlimitedSchedulerGrpcPort }:50051 \
+                    -p ${ AiUnlimitedSchedulerHttpPort }:50061 \
                     -v /etc/td/ai-unlimited:/etc/td \
                     -e TD_WSSCHED_LOG_PATH=/etc/td/workspaces/scheduler_logs \
                     -e TD_WSSCHED_TASK_LOG_PATH=/etc/td/workspaces/scheduler_logs/projects \
@@ -653,10 +667,6 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
         - FromPort: !Ref AiUnlimitedGrpcPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedGrpcPort
@@ -667,10 +677,6 @@ Resources:
           SourcePrefixListId: !If
             - HASPREFIXLIST
             - !Ref PrefixList
-            - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
             - !Ref AWS::NoValue
         - FromPort: !Ref JupyterHttpPort
           IpProtocol: tcp
@@ -683,13 +689,9 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
-        - FromPort: !Ref AiUnlimitedSchedulerPort
+        - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
-          ToPort: !Ref AiUnlimitedSchedulerPort
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -698,11 +700,18 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
+        - FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          IpProtocol: tcp
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
             - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLISTORSECGROUP
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLIST
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -733,6 +742,26 @@ Resources:
       LoadBalancerArn: !Ref LoadBalancer
       Port: !Ref JupyterHttpPort
       Protocol: TCP
+
+  AiUnlimitedSchedulerHTTPListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref AiUnlimitedSchedulerHTTPTargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: !Ref AiUnlimitedSchedulerHttpPort
+      Protocol: HTTP
+
+  AiUnlimitedSchedulerGRPCListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref AiUnlimitedSchedulerGRPCTargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: !Ref AiUnlimitedSchedulerGrpcPort
+      Protocol: HTTP
 
   AiUnlimitedGRPCListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -812,6 +841,84 @@ Resources:
           Port: !Ref JupyterHttpPort
       VpcId: !Ref Vpc
 
+  AiUnlimitedSchedulerHTTPTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 15
+      HealthCheckPath: /healthcheck
+      Matcher:
+        HttpCode: "200"
+      Name: !Join
+        - '-'
+        - - !Select
+            - 4
+            - !Split
+              - '-'
+              - !Select
+                - 2
+                - !Split
+                  - /
+                  - !Ref AWS::StackId
+          - aisch
+          - ui
+          - http
+      Port: !Ref AiUnlimitedSchedulerHttpPort
+      Protocol: HTTP
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: app_cookie
+        - Key: stickiness.app_cookie.cookie_name
+          Value: TDWUNLIMITEDHTTPSSESSION
+        - Key: deregistration_delay.timeout_seconds
+          Value: "20"
+      Targets:
+        - Id: !Ref AiUnlimitedServer
+          Port: !Ref AiUnlimitedSchedulerHttpPort
+      VpcId: !Ref Vpc
+
+  AiUnlimitedSchedulerGRPCTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 15
+      Matcher:
+        GrpcCode: "0"
+      Name: !Join
+        - "-"
+        - - !Select
+            - 4
+            - !Split
+              - "-"
+              - !Select
+                - 2
+                - !Split
+                  - /
+                  - !Ref AWS::StackId
+          - aisch
+          - api
+          - grpc
+      Port: !Ref AiUnlimitedSchedulerGrpcPort
+      Protocol: TCP
+      ProtocolVersion: GRPC
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: app_cookie
+        - Key: stickiness.app_cookie.cookie_name
+          Value: TDWUNLIMITEDHTTPSSESSION
+        - Key: deregistration_delay.timeout_seconds
+          Value: "20"
+      Targets:
+        - Id: !Ref AiUnlimitedServer
+          Port: !ref AiUnlimitedSchedulerGrpcPort
+      VpcId: !Ref Vpc
+
   AiUnlimitedGRPCTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -865,6 +972,34 @@ Resources:
           FromPort: !Ref JupyterHttpPort
           ToPort: !Ref JupyterHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedHttpPort
+            ToPort: !Ref AiUnlimitedHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedGrpcPort
+            ToPort: !Ref AiUnlimitedGrpcPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedSchedulerHttpPort
+            ToPort: !Ref AiUnlimitedSchedulerHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+            ToPort: !Ref AiUnlimitedSchedulerHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -1110,9 +1245,13 @@ Outputs:
     Description: Loadbalancer access endpoint for AI Unlimited API Access
     Value: !Sub ${ LoadBalancer.DNSName }:${ AiUnlimitedGrpcPort }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: AI Unlimited Security Group
     Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+
+  LoadBalancerSecurityGroup:
+    Description: AI Unlimited Load Balancer Security Group
+    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
 
   PublicSSHConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -901,7 +901,7 @@ Resources:
           - ui
           - http
       Port: !Ref AiUnlimitedSchedulerHttpPort
-      Protocol: HTTP
+      Protocol: TCP
       TargetGroupAttributes:
         - Key: stickiness.enabled
           Value: true

--- a/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template with AI Unlimited with Jupyter: AI Unlimited is a instance based service for deploying and suspending ai-unlimited clusters, and managing project lifecycles. This template also includes a Jupyter Lab service running on the same host, suitable for demonstration environments.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -31,7 +31,8 @@ Metadata:
           - AiUnlimitedGrpcPort
           - AiUnlimitedVersion
           - AiUnlimitedSchedulerVersion
-          - AiUnlimitedSchedulerPort
+          - AiUnlimitedSchedulerHttpPort
+          - AiUnlimitedSchedulerGrpcPort
       - Label:
           default: Persistent volume
         Parameters:
@@ -115,22 +116,32 @@ Parameters:
     MinValue: 0
     MaxValue: 65535
 
-  # AiUnlimitedSchedulerPort:
-  #   Description: port to access the AI Unlimited Scheduler API.
-  #   Type: Number
-  #   Default: 50051
-  #   ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-  #   MinValue: 0
-  #   MaxValue: 65535
+  AiUnlimitedSchedulerHttpPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50061
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
+  AiUnlimitedSchedulerGrpcPort:
+    Description: port to access the AI Unlimited Scheduler API.
+    Type: Number
+    Default: 50051
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    MinValue: 0
+    MaxValue: 65535
+
   AiUnlimitedVersion:
     Description: Which version of AI Unlimited to deploy, uses container version tags, defaults to "latest"
     Type: String
     Default: latest
 
-  # AiUnlimitedSchedulerVersion:
-  #   Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
-  #   Type: String
-  #   Default: latest
+  AiUnlimitedSchedulerVersion:
+    Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
+    Type: String
+    Default: latest
+
   JupyterHttpPort:
     Description: port to access the Jupyter UI.
     Type: Number
@@ -314,6 +325,10 @@ Conditions:
     - !Equals
       - !Ref SecurityGroup
       - ""
+
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
 
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
@@ -508,8 +523,8 @@ Resources:
                 ExecStartPre=/usr/bin/docker pull teradata/ai-unlimited-scheduler:latest
                 ExecStart=/usr/bin/docker run \
                     --network ai_unlimited \
-                    -p 50051:50051 \
-                    -p 50061:50061 \
+                    -p ${ AiUnlimitedSchedulerGrpcPort }:50051 \
+                    -p ${ AiUnlimitedSchedulerHttpPort }:50061 \
                     -v /etc/td/ai-unlimited:/etc/td \
                     -e TD_WSSCHED_LOG_PATH=/etc/td/workspaces/scheduler_logs \
                     -e TD_WSSCHED_TASK_LOG_PATH=/etc/td/workspaces/scheduler_logs/projects \
@@ -654,9 +669,24 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
-        - FromPort: 50061
+        - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
-          ToPort: 50061
+          ToPort: !Ref AiUnlimitedSchedulerHttpPort
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+        - FromPort: !Ref AiUnlimitedSchedulerGrpcPort
+          IpProtocol: tcp
+          ToPort: !Ref AiUnlimitedSchedulerGrpcPort
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -940,7 +970,7 @@ Outputs:
     Description: Teradata AI Unlimited private API Access
     Value: !Sub http://${AiUnlimitedServer.PrivateDnsName}:${ AiUnlimitedGrpcPort }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: AI Unlimited Security Group
     Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
 

--- a/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
@@ -593,6 +593,12 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
+            - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+            - !GetAtt JupyterSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -669,6 +675,13 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
+
+  AiUnlimitedSchedulerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to AI Unlimited server over http and grpc
+      SecurityGroupIngress:
         - FromPort: !Ref AiUnlimitedSchedulerHttpPort
           IpProtocol: tcp
           ToPort: !Ref AiUnlimitedSchedulerHttpPort
@@ -699,6 +712,13 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
+
+  JupyterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref Vpc
+      GroupDescription: Enable access to jupyter server over http
+      SecurityGroupIngress:
         - FromPort: !Ref JupyterHttpPort
           IpProtocol: tcp
           ToPort: !Ref JupyterHttpPort
@@ -970,9 +990,17 @@ Outputs:
     Description: Teradata AI Unlimited private API Access
     Value: !Sub http://${AiUnlimitedServer.PrivateDnsName}:${ AiUnlimitedGrpcPort }
 
-  InstanceSecurityGroup:
+  InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !GetAtt AiUnlimitedSecurityGroup.GroupId
+    Value: !Join 
+      - ', '
+      - - !GetAtt AiUnlimitedSecurityGroup.GroupId
+        - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
+        - !GetAtt JupyterSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
   PublicSSHConeection:
     Description: AI Unlimited ssh connnection string

--- a/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template with AI Unlimited with Jupyter: AI Unlimited is a instance based service for deploying and suspending ai-unlimited clusters, and managing project lifecycles. This template also includes a Jupyter Lab service running on the same host, suitable for demonstration environments.  Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -992,7 +992,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt AiUnlimitedSecurityGroup.GroupId
         - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId

--- a/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
@@ -508,6 +508,10 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt JupyterSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -568,7 +572,11 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLIST
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -784,13 +792,21 @@ Outputs:
     Description: Loadbalancer access endpoint for API Access
     Value: !Sub https://${ DnsName }:${ JupyterHttpPort }?token=${ JupyterToken }
 
-  InstanceSecurityGroup:
-    Description: Jupyter Security Group
-    Value: !GetAtt JupyterSecurityGroup.GroupId
+  InstanceSecurityGroups:
+    Description: AI Unlimited Security Group
+    Value: !Join 
+      - ', '
+      - - !GetAtt JupyterSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
-  LoadBalancerSecurityGroup:
-    Description: Jupyter Load Balancer Security Group
-    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
+  LoadBalancerSecurityGroups:
+    Description: AI Unlimited Load Balancer Security Group
+    Value: !Join 
+      - ', '
+      - - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
 
   PublicSSHConeection:
     Description: Jupyter ssh connnection string

--- a/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template jupyter: a jupyter instance configured with the ai-unlimited kernel. Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -317,6 +317,10 @@ Conditions:
       - !Ref SecurityGroup
       - ""
 
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
+
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
     - !Condition HASPREFIXLIST
@@ -564,11 +568,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLISTORSECGROUP
+    Condition: HASCIDRORPREFIXLIST
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -641,6 +641,13 @@ Resources:
           FromPort: !Ref JupyterHttpPort
           ToPort: !Ref JupyterHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref JupyterHttpPort
+            ToPort: !Ref JupyterHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -777,9 +784,13 @@ Outputs:
     Description: Loadbalancer access endpoint for API Access
     Value: !Sub https://${ DnsName }:${ JupyterHttpPort }?token=${ JupyterToken }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: Jupyter Security Group
     Value: !GetAtt JupyterSecurityGroup.GroupId
+
+  LoadBalancerSecurityGroup:
+    Description: Jupyter Load Balancer Security Group
+    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
 
   PublicSSHConeection:
     Description: Jupyter ssh connnection string

--- a/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template jupyter: a jupyter instance configured with the ai-unlimited kernel. Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -572,7 +572,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -649,7 +649,7 @@ Resources:
           FromPort: !Ref JupyterHttpPort
           ToPort: !Ref JupyterHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref JupyterHttpPort
@@ -794,7 +794,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt JupyterSecurityGroup.GroupId
         - !If
@@ -804,7 +804,7 @@ Outputs:
 
   LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
 

--- a/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
@@ -555,7 +555,7 @@ Resources:
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource JupyterServer --configsets jupyter_install --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource JupyterServer --region ${AWS::Region}
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerJupyterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref Vpc
@@ -586,7 +586,7 @@ Resources:
         - !Ref LoadBalancerSubnetOne
         - !Ref LoadBalancerSubnetTwo
       SecurityGroups:
-        - !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
       Type: application
 
   JupyterHTTPListener:
@@ -648,7 +648,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: !Ref JupyterHttpPort
           ToPort: !Ref JupyterHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
         - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp

--- a/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template jupyter: a jupyter instance configured with the ai-unlimited kernel. Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -560,7 +560,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If 
+          SourceSecurityGroupId: !If
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
@@ -630,7 +630,7 @@ Resources:
           FromPort: !Ref JupyterHttpPort
           ToPort: !Ref JupyterHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
-        - !If 
+        - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
             FromPort: !Ref JupyterHttpPort
@@ -755,7 +755,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt JupyterSecurityGroup.GroupId
         - !If
@@ -765,7 +765,7 @@ Outputs:
 
   LoadBalancerSecurityGroups:
     Description: AI Unlimited Load Balancer Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
 

--- a/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
@@ -543,7 +543,7 @@ Resources:
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource JupyterServer --configsets jupyter_install --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource JupyterServer --region ${AWS::Region}
 
-  LoadBalancerSecurityGroup:
+  LoadBalancerJupyterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref Vpc
@@ -573,7 +573,7 @@ Resources:
       Subnets:
         - !Ref LoadBalancerSubnet
       SecurityGroups:
-        - !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
       Type: network
 
   JupyterHTTPListener:
@@ -629,7 +629,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: !Ref JupyterHttpPort
           ToPort: !Ref JupyterHttpPort
-          SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+          SourceSecurityGroupId: !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
         - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp

--- a/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template jupyter: a jupyter instance configured with the ai-unlimited kernel. Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -305,6 +305,10 @@ Conditions:
       - !Ref SecurityGroup
       - ""
 
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
+
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
     - !Condition HASPREFIXLIST
@@ -552,11 +556,7 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-          SourceSecurityGroupId: !If
-            - HASSECURITYGROUP
-            - !Ref SecurityGroup
-            - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLISTORSECGROUP
+    Condition: HASCIDRORPREFIXLIST
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -622,6 +622,13 @@ Resources:
           FromPort: !Ref JupyterHttpPort
           ToPort: !Ref JupyterHttpPort
           SourceSecurityGroupId: !GetAtt LoadBalancerSecurityGroup.GroupId
+        - !If 
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: !Ref JupyterHttpPort
+            ToPort: !Ref JupyterHttpPort
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
 
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -738,9 +745,13 @@ Outputs:
     Description: Loadbalancer access endpoint for API Access
     Value: !Sub http://${ LoadBalancer.DNSName }:${ JupyterHttpPort }?token=${ JupyterToken }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: Jupyter Security Group
     Value: !GetAtt JupyterSecurityGroup.GroupId
+
+  LoadBalancerSecurityGroup:
+    Description: Jupyter Load Balancer Security Group
+    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
 
   PublicSSHConeection:
     Description: Jupyter ssh connnection string

--- a/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
@@ -496,6 +496,10 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt JupyterSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -556,7 +560,11 @@ Resources:
             - HASPREFIXLIST
             - !Ref PrefixList
             - !Ref AWS::NoValue
-    Condition: HASCIDRORPREFIXLIST
+          SourceSecurityGroupId: !If 
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+    Condition: HASCIDRORPREFIXLISTORSECGROUP
 
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -745,13 +753,21 @@ Outputs:
     Description: Loadbalancer access endpoint for API Access
     Value: !Sub http://${ LoadBalancer.DNSName }:${ JupyterHttpPort }?token=${ JupyterToken }
 
-  InstanceSecurityGroup:
-    Description: Jupyter Security Group
-    Value: !GetAtt JupyterSecurityGroup.GroupId
+  InstanceSecurityGroups:
+    Description: AI Unlimited Security Group
+    Value: !Join 
+      - ', '
+      - - !GetAtt JupyterSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
-  LoadBalancerSecurityGroup:
-    Description: Jupyter Load Balancer Security Group
-    Value: !GetAtt LoadBalancerSecurityGroup.GroupId
+  LoadBalancerSecurityGroups:
+    Description: AI Unlimited Load Balancer Security Group
+    Value: !Join 
+      - ', '
+      - - !GetAtt LoadBalancerJupyterSecurityGroup.GroupId
 
   PublicSSHConeection:
     Description: Jupyter ssh connnection string

--- a/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: 'AWS CloudFormation Template jupyter: a jupyter instance configured with the ai-unlimited kernel. Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -673,7 +673,7 @@ Outputs:
 
   InstanceSecurityGroups:
     Description: AI Unlimited Security Group
-    Value: !Join 
+    Value: !Join
       - ', '
       - - !GetAtt JupyterSecurityGroup.GroupId
         - !If

--- a/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Description: 'AWS CloudFormation Template jupyter: a jupyter instance configured with the ai-unlimited kernel. Note: You will be billed for the AWS resources used if you create a stack from this template.'
 
@@ -289,6 +289,10 @@ Conditions:
     - !Equals
       - !Ref SecurityGroup
       - ""
+
+  HASCIDRORPREFIXLIST: !Or
+    - !Condition HASCIDR
+    - !Condition HASPREFIXLIST
 
   HASCIDRORPREFIXLISTORSECGROUP: !Or
     - !Condition HASCIDR
@@ -663,7 +667,7 @@ Outputs:
     Description: Teradata jupyter Server
     Value: !Sub http://${JupyterServer.PrivateDnsName}:${ JupyterHttpPort }?token=${ JupyterToken }
 
-  SecurityGroup:
+  InstanceSecurityGroup:
     Description: Jupyter Security Group
     Value: !GetAtt JupyterSecurityGroup.GroupId
 

--- a/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
@@ -481,6 +481,10 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt JupyterSecurityGroup.GroupId
+            - !If
+              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+              - !GetAtt SecurityGroupIngress.GroupId
+              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true
@@ -667,9 +671,15 @@ Outputs:
     Description: Teradata jupyter Server
     Value: !Sub http://${JupyterServer.PrivateDnsName}:${ JupyterHttpPort }?token=${ JupyterToken }
 
-  InstanceSecurityGroup:
-    Description: Jupyter Security Group
-    Value: !GetAtt JupyterSecurityGroup.GroupId
+  InstanceSecurityGroups:
+    Description: AI Unlimited Security Group
+    Value: !Join 
+      - ', '
+      - - !GetAtt JupyterSecurityGroup.GroupId
+        - !If
+          - HASKEYANDCIDRORPREFIXLISTORSECGROUP
+          - !GetAtt SecurityGroupIngress.GroupId
+          - !Ref AWS::NoValue
 
   PublicSSHConeection:
     Description: Jupyter ssh connnection string


### PR DESCRIPTION
There is a maximum number of security group rules for each security group. With the addition of the the scheduler ports, long prefix lists are creating errors on deployment by exceeding the rule limts. This change breaks security groups into smaller groups to help avoid the issue. 

This also enables both ports for the scheduler on all manager instances / load balancers in AWS.

Additionally, the ssh security group was not being attached to the instance ( it is never enabled through the load balancer ), this change includes the ssh security group if a ssh key has been provided.