### PR TITLE
fix: add access policies to correct vault name 

### DIFF
--- a/deployments/azure/templates/arm/all-in-one/all-in-one-with-nlb.json
+++ b/deployments/azure/templates/arm/all-in-one/all-in-one-with-nlb.json
@@ -314,7 +314,7 @@
         "mode": "Incremental",
         "parameters": {
           "vaultName": {
-            "value": "[parameters('AiUnlimitedName')]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'vault'), '2022-09-01').outputs.name.value]"
           },
           "accessPolicy": {
             "value": {

--- a/deployments/azure/templates/arm/all-in-one/all-in-one-without-lb.json
+++ b/deployments/azure/templates/arm/all-in-one/all-in-one-without-lb.json
@@ -313,7 +313,7 @@
         "mode": "Incremental",
         "parameters": {
           "vaultName": {
-            "value": "[parameters('AiUnlimitedName')]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'vault'), '2022-09-01').outputs.name.value]"
           },
           "accessPolicy": {
             "value": {

--- a/deployments/azure/templates/bicep/all-in-one/all-in-one-with-nlb.bicep
+++ b/deployments/azure/templates/bicep/all-in-one/all-in-one-with-nlb.bicep
@@ -169,7 +169,7 @@ module vaultAccessPolicy '../modules/vault/access-policy.bicep' = if (UseKeyVaul
   scope: rg
   name: 'vault-access-policy'
   params: {
-    vaultName: AiUnlimitedName
+    vaultName: vault.outputs.name
     accessPolicy: {
       tenantId: subscription().tenantId
       objectId: aiUnlimited.outputs.PrincipleId

--- a/deployments/azure/templates/bicep/all-in-one/all-in-one-without-lb.bicep
+++ b/deployments/azure/templates/bicep/all-in-one/all-in-one-without-lb.bicep
@@ -167,7 +167,7 @@ module vaultAccessPolicy '../modules/vault/access-policy.bicep' = if (UseKeyVaul
   scope: rg
   name: 'vault-access-policy'
   params: {
-    vaultName: AiUnlimitedName
+    vaultName: vault.outputs.name
     accessPolicy: {
       tenantId: subscription().tenantId
       objectId: aiUnlimited.outputs.PrincipleId


### PR DESCRIPTION
Awhile back, I made a change in this pr (https://github.com/Teradata/ai-unlimited/pull/34) to make the vault name unique. I forgot to update the all-in-one templates. 

Adding this fix in to fix the bug I introduced.