### PR TITLE
remove SecurityGroupIngress.GroupId from NetworkInterfaces.

### DIFF
--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-alb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-alb.yaml
@@ -568,10 +568,6 @@ Resources:
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
             - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -553,10 +553,6 @@ Resources:
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
             - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -539,10 +539,6 @@ Resources:
           GroupSet:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
             - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true

--- a/deployments/aws/templates/all-in-one/all-in-one-with-alb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-alb.yaml
@@ -628,10 +628,6 @@ Resources:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
             - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
             - !GetAtt JupyterSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -612,10 +612,6 @@ Resources:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
             - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
             - !GetAtt JupyterSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true

--- a/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
@@ -595,10 +595,6 @@ Resources:
             - !GetAtt AiUnlimitedSecurityGroup.GroupId
             - !GetAtt AiUnlimitedSchedulerSecurityGroup.GroupId
             - !GetAtt JupyterSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true

--- a/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-alb.yaml
@@ -508,10 +508,6 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt JupyterSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true

--- a/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
@@ -496,10 +496,6 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt JupyterSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true

--- a/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
@@ -481,10 +481,6 @@ Resources:
           SubnetId: !Ref Subnet
           GroupSet:
             - !GetAtt JupyterSecurityGroup.GroupId
-            - !If
-              - HASKEYANDCIDRORPREFIXLISTORSECGROUP
-              - !GetAtt SecurityGroupIngress.GroupId
-              - !Ref AWS::NoValue
           AssociatePublicIpAddress: !If
             - HASPUBLICIP
             - true


### PR DESCRIPTION
Cloudformations errors on the lookup, and it is no longer required. The group id would be the same the always added instance security group. The ingress has been directly added to the instance group already.