### PR TITLE
Add feature to enable TLS on Cloud

### DIFF
--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -137,12 +137,12 @@ Parameters:
   AiUnlimitedVersion:
     Description: Which version of AI Unlimited to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.3.0
+    Default: v0.3.2
 
   AiUnlimitedUiVersion:
     Description: Which version of AI Unlimited UI to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.0.6
+    Default: v0.0.7
 
   AiUnlimitedSchedulerVersion:
     Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -35,7 +35,6 @@ Metadata:
           - AiUnlimitedSchedulerVersion
           - AiUnlimitedSchedulerHttpPort
           - AiUnlimitedSchedulerGrpcPort
-          - AiUnlimitedUiPort
           - AiUnlimitedUiVersion
       - Label:
           default: Persistent volume
@@ -123,14 +122,6 @@ Parameters:
     Description: port to access the AI Unlimited Scheduler API.
     Type: Number
     Default: 50051
-    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-    MinValue: 0
-    MaxValue: 65535
-
-  AiUnlimitedUiPort:
-    Description: port to access the AI Unlimited UI.
-    Type: Number
-    Default: 80
     ConstraintDescription: must be a valid ununsed port between 0 and 65535.
     MinValue: 0
     MaxValue: 65535
@@ -379,11 +370,6 @@ Conditions:
       - !Ref IamRoleName
       - ""
 
-  PortIsNotEighty: !Not
-    - !Equals
-      - !Ref AiUnlimitedUiPort
-      - 80
-
 Resources:
   AiUnlimitedVolume:
     DeletionPolicy: !Ref PersistentVolumeDeletionPolicy
@@ -521,8 +507,6 @@ Resources:
                 ExecStartPre=-/usr/bin/docker rm %n || true
                 ExecStartPre=/usr/bin/docker pull teradata/ai-unlimited-workspaces-ui:${ AiUnlimitedUiVersion }
                 ExecStart=/usr/bin/docker run \
-                  -e accept_license=Y \
-                  -e PLATFORM=aws \
                   -e TD_VCD_USE_TLS=false \
                   -e TD_VCD_API_PORT=${ AiUnlimitedGrpcPort } \
                   -e TD_VCD_AUTH_PORT=${ AiUnlimitedAuthPort } \
@@ -567,7 +551,6 @@ Resources:
                     -e accept_license=Y \
                     -e PLATFORM=aws \
                     -e TD_VCD_INIT_API_KEY \
-                    -v /etc/td/ai-unlimited:/etc/td \
                     -p ${ AiUnlimitedAuthPort }:3000 \
                     -p ${ AiUnlimitedGrpcPort }:3282 \
                     -v /etc/td/ai-unlimited:/etc/td \
@@ -710,9 +693,24 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
-        - FromPort: !Ref AiUnlimitedUiPort
+        - FromPort: 80
           IpProtocol: tcp
-          ToPort: !Ref AiUnlimitedUiPort
+          ToPort: 80
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+        - FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -799,7 +797,17 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref AiUnlimitedUITargetGroup
       LoadBalancerArn: !Ref LoadBalancer
-      Port: !Ref AiUnlimitedUiPort
+      Port: 80
+      Protocol: TCP
+
+  AiUnlimitedUISSLListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref AiUnlimitedUITargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
       Protocol: TCP
 
   AiUnlimitedSchedulerHTTPListener:
@@ -876,7 +884,7 @@ Resources:
           - td-aiu
           - ui
           - api
-      Port: !Ref AiUnlimitedUiPort
+      Port: 80
       Protocol: TCP
       TargetGroupAttributes:
         - Key: stickiness.enabled
@@ -887,7 +895,7 @@ Resources:
           Value: "20"
       Targets:
         - Id: !Ref AiUnlimitedServer
-          Port: !Ref AiUnlimitedUiPort
+          Port: 80
       VpcId: !Ref Vpc
 
   AiUnlimitedGRPCTargetGroup:
@@ -1011,8 +1019,12 @@ Resources:
           ToPort: !Ref AiUnlimitedGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - IpProtocol: tcp
-          FromPort: !Ref AiUnlimitedUiPort
-          ToPort: !Ref AiUnlimitedUiPort
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !If
           - HASSECURITYGROUP
@@ -1031,8 +1043,8 @@ Resources:
         - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
-            FromPort: !Ref AiUnlimitedUiPort
-            ToPort: !Ref AiUnlimitedUiPort
+            FromPort: 80
+            ToPort: 80
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
 
@@ -1307,10 +1319,7 @@ Outputs:
 
   AiUnlimitedUiAccess:
     Description: Loadbalancer access endpoint for AI Unlimited UI Access
-    Value: !If
-      - PortIsNotEighty
-      - !Sub http://${ LoadBalancer.DNSName }:${ AiUnlimitedUiPort }/healthcheck
-      - !Sub http://${ LoadBalancer.DNSName }
+    Value: !Sub http://${ LoadBalancer.DNSName }
 
   AiUnlimitedApiAccess:
     Description: Loadbalancer access endpoint for AI Unlimited API Access

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -805,7 +805,7 @@ Resources:
     Properties:
       DefaultActions:
         - Type: forward
-          TargetGroupArn: !Ref AiUnlimitedUITargetGroup
+          TargetGroupArn: !Ref AiUnlimitedUIHTTPSTargetGroup
       LoadBalancerArn: !Ref LoadBalancer
       Port: 443
       Protocol: TCP
@@ -883,6 +883,7 @@ Resources:
                   - !Ref AWS::StackId
           - td-aiu
           - ui
+          - http
           - api
       Port: 80
       Protocol: TCP
@@ -896,6 +897,41 @@ Resources:
       Targets:
         - Id: !Ref AiUnlimitedServer
           Port: 80
+      VpcId: !Ref Vpc
+
+  AiUnlimitedUIHTTPSTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckProtocol: HTTPS
+      HealthCheckTimeoutSeconds: 15
+      Name: !Join
+        - '-'
+        - - !Select
+            - 4
+            - !Split
+              - '-'
+              - !Select
+                - 2
+                - !Split
+                  - /
+                  - !Ref AWS::StackId
+          - td-aiu
+          - ui
+          - https
+          - api
+      Port: 443
+      Protocol: TCP
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: source_ip
+        - Key: deregistration_delay.timeout_seconds
+          Value: "20"
+      Targets:
+        - Id: !Ref AiUnlimitedServer
+          Port: 443
       VpcId: !Ref Vpc
 
   AiUnlimitedGRPCTargetGroup:
@@ -1045,6 +1081,13 @@ Resources:
           - IpProtocol: tcp
             FromPort: 80
             ToPort: 80
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: 443
+            ToPort: 443
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
 

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-with-nlb.yaml
@@ -513,6 +513,7 @@ Resources:
                 Restart=always
                 RestartSec=2
 
+                ExecStartPre=-/bin/bash -c '/usr/bin/docker volume create ssl_certs || true'
                 ExecStartPre=-/bin/bash -c '/usr/bin/docker network create -d bridge ai_unlimited || true'
                 ExecStartPre=-/usr/bin/mkdir -p /etc/td/ai-unlimited-ui
                 EnvironmentFile=/etc/td/ai-unlimited/init_api_key.txt
@@ -522,11 +523,13 @@ Resources:
                 ExecStart=/usr/bin/docker run \
                   -e accept_license=Y \
                   -e PLATFORM=aws \
-                  -e TD_VCD_UI_PORT=${ AiUnlimitedUiPort } \
+                  -e TD_VCD_USE_TLS=false \
                   -e TD_VCD_API_PORT=${ AiUnlimitedGrpcPort } \
                   -e TD_VCD_AUTH_PORT=${ AiUnlimitedAuthPort } \
                   -e TD_VCD_INIT_API_KEY \
-                  -p ${ AiUnlimitedUiPort }:80 \
+                  -p 80:80 \
+                  -p 443:443 \
+                  -v ssl_certs:/etc/ssl/td \
                   --network ai_unlimited \
                   --rm --name %n teradata/ai-unlimited-workspaces-ui:${ AiUnlimitedUiVersion }
                 [Install]
@@ -567,6 +570,8 @@ Resources:
                     -v /etc/td/ai-unlimited:/etc/td \
                     -p ${ AiUnlimitedAuthPort }:3000 \
                     -p ${ AiUnlimitedGrpcPort }:3282 \
+                    -v /etc/td/ai-unlimited:/etc/td \
+                    -v ssl_certs:/etc/td/ssl \
                     --network ai_unlimited \
                     --rm --name %n teradata/ai-unlimited-workspaces:${ AiUnlimitedVersion } workspaces serve -v
 

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -715,6 +715,7 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
+
   AiUnlimitedSchedulerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -508,6 +508,7 @@ Resources:
                 Restart=always
                 RestartSec=2
 
+                ExecStartPre=-/bin/bash -c '/usr/bin/docker volume create ssl_certs || true'
                 ExecStartPre=-/bin/bash -c '/usr/bin/docker network create -d bridge ai_unlimited || true'
                 ExecStartPre=-/usr/bin/mkdir -p /etc/td/ai-unlimited-ui
                 EnvironmentFile=/etc/td/ai-unlimited/init_api_key.txt
@@ -517,11 +518,13 @@ Resources:
                 ExecStart=/usr/bin/docker run \
                   -e accept_license=Y \
                   -e PLATFORM=aws \
-                  -e TD_VCD_UI_PORT=${ AiUnlimitedUiPort } \
+                  -e TD_VCD_USE_TLS=false \
                   -e TD_VCD_API_PORT=${ AiUnlimitedGrpcPort } \
                   -e TD_VCD_AUTH_PORT=${ AiUnlimitedAuthPort } \
                   -e TD_VCD_INIT_API_KEY \
-                  -p ${ AiUnlimitedUiPort }:80 \
+                  -p 80:80 \
+                  -p 443:443 \
+                  -v ssl_certs:/etc/ssl/td \
                   --network ai_unlimited \
                   --rm --name %n teradata/ai-unlimited-workspaces-ui:${ AiUnlimitedUiVersion }
                 [Install]
@@ -562,6 +565,8 @@ Resources:
                     -v /etc/td/ai-unlimited:/etc/td \
                     -p ${ AiUnlimitedAuthPort }:3000 \
                     -p ${ AiUnlimitedGrpcPort }:3282 \
+                    -v /etc/td/ai-unlimited:/etc/td \
+                    -v ssl_certs:/etc/td/ssl \
                     --network ai_unlimited \
                     --rm --name %n teradata/ai-unlimited-workspaces:${ AiUnlimitedVersion } workspaces serve -v
 

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -700,7 +700,21 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
-
+        - FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
   AiUnlimitedSchedulerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -122,7 +122,7 @@ Parameters:
   AiUnlimitedVersion:
     Description: Which version of AI Unlimited to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.3.0
+    Default: v0.3.2
 
   AiUnlimitedSchedulerVersion:
     Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
@@ -132,7 +132,7 @@ Parameters:
   AiUnlimitedUiVersion:
     Description: Which version of AI Unlimited UI to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.0.6
+    Default: v0.0.7
 
   RootVolumeSize:
     Description: size of the root disk to the AI Unlimited server.

--- a/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
+++ b/deployments/aws/templates/ai-unlimited/ai-unlimited-without-lb.yaml
@@ -33,7 +33,6 @@ Metadata:
           - AiUnlimitedSchedulerVersion
           - AiUnlimitedSchedulerHttpPort
           - AiUnlimitedSchedulerGrpcPort
-          - AiUnlimitedUiPort
           - AiUnlimitedUiVersion
       - Label:
           default: Persistent volume
@@ -116,14 +115,6 @@ Parameters:
     Description: port to access the AI Unlimited Scheduler API.
     Type: Number
     Default: 50051
-    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-    MinValue: 0
-    MaxValue: 65535
-
-  AiUnlimitedUiPort:
-    Description: port to access the AI Unlimited UI.
-    Type: Number
-    Default: 80
     ConstraintDescription: must be a valid ununsed port between 0 and 65535.
     MinValue: 0
     MaxValue: 65535
@@ -364,21 +355,6 @@ Conditions:
       - !Ref IamRoleName
       - ""
 
-  PortIsNotEightyAndHasPublicIp: !And
-    - !Not
-      - !Equals
-        - !Ref Private
-        - "true"
-    - !Not
-      - !Equals
-        - !Ref AiUnlimitedUiPort
-        - 80
-
-  PortIsNotEighty: !Not
-    - !Equals
-      - !Ref AiUnlimitedUiPort
-      - 80
-
 Resources:
   AiUnlimitedVolume:
     DeletionPolicy: !Ref PersistentVolumeDeletionPolicy
@@ -562,7 +538,6 @@ Resources:
                     -e accept_license=Y \
                     -e PLATFORM=aws \
                     -e TD_VCD_INIT_API_KEY \
-                    -v /etc/td/ai-unlimited:/etc/td \
                     -p ${ AiUnlimitedAuthPort }:3000 \
                     -p ${ AiUnlimitedGrpcPort }:3282 \
                     -v /etc/td/ai-unlimited:/etc/td \
@@ -710,9 +685,9 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
-        - FromPort: !Ref AiUnlimitedUiPort
+        - FromPort: 80
           IpProtocol: tcp
-          ToPort: !Ref AiUnlimitedUiPort
+          ToPort: 80
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -1002,18 +977,12 @@ Outputs:
 
   AiUnlimitedPublicUIAccess:
     Description: Teradata AI Unlimited public UI Access
-    Value: !If
-      - PortIsNotEightyAndHasPublicIp
-      - !Sub http://${AiUnlimitedServer.PublicDnsName}:${AiUnlimitedUiPort}/healthcheck
-      - !Sub http://${AiUnlimitedServer.PublicDnsName}
+    Value: !Sub http://${AiUnlimitedServer.PublicDnsName}
     Condition: HASPUBLICIP
 
   AiUnlimitedPrivateUIAccess:
     Description: Teradata AI Unlimited private UI Access
-    Value: !If
-      - PortIsNotEighty
-      - !Sub http://${AiUnlimitedServer.PrivateDnsName}:${AiUnlimitedUiPort}/healthcheck
-      - !Sub http://${AiUnlimitedServer.PrivateDnsName}
+    Value: !Sub http://${AiUnlimitedServer.PrivateDnsName}
 
   AiUnlimitedPublicAPIAccess:
     Description: Teradata AI Unlimited public API Access

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -35,7 +35,6 @@ Metadata:
           - AiUnlimitedSchedulerVersion
           - AiUnlimitedSchedulerHttpPort
           - AiUnlimitedSchedulerGrpcPort
-          - AiUnlimitedUiPort
           - AiUnlimitedUiVersion
       - Label:
           default: Persistent volume
@@ -145,14 +144,6 @@ Parameters:
     Description: port to access the AI Unlimited Scheduler API.
     Type: Number
     Default: 50051
-    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-    MinValue: 0
-    MaxValue: 65535
-
-  AiUnlimitedUiPort:
-    Description: port to access the AI Unlimited UI.
-    Type: Number
-    Default: 80
     ConstraintDescription: must be a valid ununsed port between 0 and 65535.
     MinValue: 0
     MaxValue: 65535
@@ -395,11 +386,6 @@ Conditions:
       - !Ref IamRoleName
       - ""
 
-  PortIsNotEighty: !Not
-    - !Equals
-      - !Ref AiUnlimitedUiPort
-      - 80
-
 Resources:
   AiUnlimitedVolume:
     DeletionPolicy: !Ref PersistentVolumeDeletionPolicy
@@ -585,7 +571,6 @@ Resources:
                     -e accept_license=Y \
                     -e PLATFORM=aws \
                     -e TD_VCD_INIT_API_KEY \
-                    -v /etc/td/ai-unlimited:/etc/td \
                     -p ${ AiUnlimitedAuthPort }:3000 \
                     -p ${ AiUnlimitedGrpcPort }:3282 \
                     -v /etc/td/ai-unlimited:/etc/td \
@@ -769,9 +754,9 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
-        - FromPort: !Ref AiUnlimitedUiPort
+        - FromPort: 80
           IpProtocol: tcp
-          ToPort: !Ref AiUnlimitedUiPort
+          ToPort: 80
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -872,7 +857,7 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref AiUnlimitedUITargetGroup
       LoadBalancerArn: !Ref LoadBalancer
-      Port: !Ref AiUnlimitedUiPort
+      Port: 80
       Protocol: TCP
 
   JupyterHTTPListener:
@@ -969,7 +954,7 @@ Resources:
           - td-aiu
           - ui
           - api
-      Port: !Ref AiUnlimitedUiPort
+      Port: 80
       Protocol: TCP
       TargetGroupAttributes:
         - Key: stickiness.enabled
@@ -980,7 +965,7 @@ Resources:
           Value: "20"
       Targets:
         - Id: !Ref AiUnlimitedServer
-          Port: !Ref AiUnlimitedUiPort
+          Port: 80
       VpcId: !Ref Vpc
 
   JupyterHTTPTargetGroup:
@@ -1138,8 +1123,8 @@ Resources:
           ToPort: !Ref AiUnlimitedGrpcPort
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - IpProtocol: tcp
-          FromPort: !Ref AiUnlimitedUiPort
-          ToPort: !Ref AiUnlimitedUiPort
+          FromPort: 80
+          ToPort: 80
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !If
           - HASSECURITYGROUP
@@ -1158,8 +1143,8 @@ Resources:
         - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
-            FromPort: !Ref AiUnlimitedUiPort
-            ToPort: !Ref AiUnlimitedUiPort
+            FromPort: 80
+            ToPort: 80
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
 
@@ -1460,10 +1445,7 @@ Outputs:
 
   AiUnlimitedUiAccess:
     Description: Loadbalancer access endpoint for AI Unlimited UI Access
-    Value: !If
-      - PortIsNotEighty
-      - !Sub http://${ LoadBalancer.DNSName }:${ AiUnlimitedUiPort }/healthcheck
-      - !Sub http://${ LoadBalancer.DNSName }
+    Value: !Sub http://${ LoadBalancer.DNSName }
 
   AiUnlimitedApiAccess:
     Description: Loadbalancer access endpoint for AI Unlimited API Access

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -174,7 +174,7 @@ Parameters:
   JupyterVersion:
     Description: Which version of Jupyter to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.0.49
+    Default: v0.0.51
 
   RootVolumeSize:
     Description: size of the root disk to the AI Unlimited server.
@@ -769,6 +769,21 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
+        - FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
     Condition: HASCIDRORPREFIXLISTORSECGROUP
 
   LoadBalancerSchedulerSecurityGroup:
@@ -858,6 +873,16 @@ Resources:
           TargetGroupArn: !Ref AiUnlimitedUITargetGroup
       LoadBalancerArn: !Ref LoadBalancer
       Port: 80
+      Protocol: TCP
+
+  AiUnlimitedUISSLListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref AiUnlimitedUIHTTPSTargetGroup
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
       Protocol: TCP
 
   JupyterHTTPListener:
@@ -953,6 +978,7 @@ Resources:
                   - !Ref AWS::StackId
           - td-aiu
           - ui
+          - http
           - api
       Port: 80
       Protocol: TCP
@@ -966,6 +992,41 @@ Resources:
       Targets:
         - Id: !Ref AiUnlimitedServer
           Port: 80
+      VpcId: !Ref Vpc
+
+  AiUnlimitedUIHTTPSTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckProtocol: HTTPS
+      HealthCheckTimeoutSeconds: 15
+      Name: !Join
+        - '-'
+        - - !Select
+            - 4
+            - !Split
+              - '-'
+              - !Select
+                - 2
+                - !Split
+                  - /
+                  - !Ref AWS::StackId
+          - td-aiu
+          - ui
+          - https
+          - api
+      Port: 443
+      Protocol: TCP
+      TargetGroupAttributes:
+        - Key: stickiness.enabled
+          Value: true
+        - Key: stickiness.type
+          Value: source_ip
+        - Key: deregistration_delay.timeout_seconds
+          Value: "20"
+      Targets:
+        - Id: !Ref AiUnlimitedServer
+          Port: 443
       VpcId: !Ref Vpc
 
   JupyterHTTPTargetGroup:
@@ -1126,6 +1187,10 @@ Resources:
           FromPort: 80
           ToPort: 80
           SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !GetAtt LoadBalancerAiUnlimitedSecurityGroup.GroupId
         - !If
           - HASSECURITYGROUP
           - IpProtocol: tcp
@@ -1145,6 +1210,13 @@ Resources:
           - IpProtocol: tcp
             FromPort: 80
             ToPort: 80
+            SourceSecurityGroupId: !Ref SecurityGroup
+          - !Ref AWS::NoValue
+        - !If
+          - HASSECURITYGROUP
+          - IpProtocol: tcp
+            FromPort: 443
+            ToPort: 443
             SourceSecurityGroupId: !Ref SecurityGroup
           - !Ref AWS::NoValue
 

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -151,12 +151,12 @@ Parameters:
   AiUnlimitedVersion:
     Description: Which version of AI Unlimited to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.3.0
+    Default: v0.3.2
 
   AiUnlimitedUiVersion:
     Description: Which version of AI Unlimited UI to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.0.6
+    Default: v0.0.7
 
   AiUnlimitedSchedulerVersion:
     Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"

--- a/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-with-nlb.yaml
@@ -531,6 +531,7 @@ Resources:
                 Restart=always
                 RestartSec=2
 
+                ExecStartPre=-/bin/bash -c '/usr/bin/docker volume create ssl_certs || true'
                 ExecStartPre=-/bin/bash -c '/usr/bin/docker network create -d bridge ai_unlimited || true'
                 ExecStartPre=-/usr/bin/mkdir -p /etc/td/ai-unlimited-ui
                 EnvironmentFile=/etc/td/ai-unlimited/init_api_key.txt
@@ -540,11 +541,13 @@ Resources:
                 ExecStart=/usr/bin/docker run \
                   -e accept_license=Y \
                   -e PLATFORM=aws \
-                  -e TD_VCD_UI_PORT=${ AiUnlimitedUiPort } \
+                  -e TD_VCD_USE_TLS=false \
                   -e TD_VCD_API_PORT=3282 \
                   -e TD_VCD_AUTH_PORT=3000 \
                   -e TD_VCD_INIT_API_KEY \
-                  -p ${ AiUnlimitedUiPort }:80 \
+                  -p 80:80 \
+                  -p 443:443 \
+                  -v ssl_certs:/etc/ssl/td \
                   --network ai_unlimited \
                   --rm --name %n teradata/ai-unlimited-workspaces-ui:${ AiUnlimitedUiVersion }
                 [Install]
@@ -585,6 +588,8 @@ Resources:
                     -v /etc/td/ai-unlimited:/etc/td \
                     -p ${ AiUnlimitedAuthPort }:3000 \
                     -p ${ AiUnlimitedGrpcPort }:3282 \
+                    -v /etc/td/ai-unlimited:/etc/td \
+                    -v ssl_certs:/etc/td/ssl \
                     --network ai_unlimited \
                     --net-alias ${ LoadBalancer.DNSName } \
                     --rm --name %n teradata/ai-unlimited-workspaces:${ AiUnlimitedVersion } workspaces serve -v

--- a/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
@@ -526,6 +526,7 @@ Resources:
                 Restart=always
                 RestartSec=2
 
+                ExecStartPre=-/bin/bash -c '/usr/bin/docker volume create ssl_certs || true'
                 ExecStartPre=-/bin/bash -c '/usr/bin/docker network create -d bridge ai_unlimited || true'
                 ExecStartPre=-/usr/bin/mkdir -p /etc/td/ai-unlimited-ui
                 EnvironmentFile=/etc/td/ai-unlimited/init_api_key.txt
@@ -535,11 +536,13 @@ Resources:
                 ExecStart=/usr/bin/docker run \
                   -e accept_license=Y \
                   -e PLATFORM=aws \
-                  -e TD_VCD_UI_PORT=${ AiUnlimitedUiPort } \
+                  -e TD_VCD_USE_TLS=false \
                   -e TD_VCD_API_PORT=${ AiUnlimitedGrpcPort } \
                   -e TD_VCD_AUTH_PORT=${ AiUnlimitedAuthPort } \
                   -e TD_VCD_INIT_API_KEY \
-                  -p ${ AiUnlimitedUiPort }:80 \
+                  -p 80:80 \
+                  -p 443:443 \
+                  -v ssl_certs:/etc/ssl/td \
                   --network ai_unlimited \
                   --rm --name %n teradata/ai-unlimited-workspaces-ui:${ AiUnlimitedUiVersion }
                 [Install]
@@ -580,6 +583,8 @@ Resources:
                     -v /etc/td/ai-unlimited:/etc/td \
                     -p ${ AiUnlimitedAuthPort }:3000 \
                     -p ${ AiUnlimitedGrpcPort }:3282 \
+                    -v /etc/td/ai-unlimited:/etc/td \
+                    -v ssl_certs:/etc/td/ssl \
                     --network ai_unlimited \
                     --rm --name %n teradata/ai-unlimited-workspaces:${ AiUnlimitedVersion } workspaces serve -v
                 [Install]

--- a/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
@@ -33,7 +33,6 @@ Metadata:
           - AiUnlimitedSchedulerVersion
           - AiUnlimitedSchedulerHttpPort
           - AiUnlimitedSchedulerGrpcPort
-          - AiUnlimitedUiPort
           - AiUnlimitedUiVersion
       - Label:
           default: Persistent volume
@@ -130,14 +129,6 @@ Parameters:
     Description: port to access the AI Unlimited Scheduler API.
     Type: Number
     Default: 50051
-    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
-    MinValue: 0
-    MaxValue: 65535
-
-  AiUnlimitedUiPort:
-    Description: port to access the AI Unlimited UI.
-    Type: Number
-    Default: 80
     ConstraintDescription: must be a valid ununsed port between 0 and 65535.
     MinValue: 0
     MaxValue: 65535
@@ -380,21 +371,6 @@ Conditions:
       - !Ref IamRoleName
       - ""
 
-  PortIsNotEightyAndHasPublicIp: !And
-    - !Not
-      - !Equals
-        - !Ref Private
-        - "true"
-    - !Not
-      - !Equals
-        - !Ref AiUnlimitedUiPort
-        - 80
-
-  PortIsNotEighty: !Not
-    - !Equals
-      - !Ref AiUnlimitedUiPort
-      - 80
-
 Resources:
   AiUnlimitedVolume:
     DeletionPolicy: !Ref PersistentVolumeDeletionPolicy
@@ -580,7 +556,6 @@ Resources:
                     -e accept_license=Y \
                     -e PLATFORM=aws \
                     -e TD_VCD_INIT_API_KEY \
-                    -v /etc/td/ai-unlimited:/etc/td \
                     -p ${ AiUnlimitedAuthPort }:3000 \
                     -p ${ AiUnlimitedGrpcPort }:3282 \
                     -v /etc/td/ai-unlimited:/etc/td \
@@ -766,9 +741,9 @@ Resources:
             - HASSECURITYGROUP
             - !Ref SecurityGroup
             - !Ref AWS::NoValue
-        - FromPort: !Ref AiUnlimitedUiPort
+        - FromPort: 80
           IpProtocol: tcp
-          ToPort: !Ref AiUnlimitedUiPort
+          ToPort: 80
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR
@@ -1084,18 +1059,12 @@ Outputs:
 
   AiUnlimitedPublicUIAccess:
     Description: Teradata AI Unlimited public UI Access
-    Value: !If
-      - PortIsNotEightyAndHasPublicIp
-      - !Sub http://${AiUnlimitedServer.PublicDnsName}:${AiUnlimitedUiPort}/healthcheck
-      - !Sub http://${AiUnlimitedServer.PublicDnsName}
+    Value: !Sub http://${AiUnlimitedServer.PublicDnsName}
     Condition: HASPUBLICIP
 
   AiUnlimitedPrivateUIAccess:
     Description: Teradata AI Unlimited private UI Access
-    Value: !If
-      - PortIsNotEighty
-      - !Sub http://${AiUnlimitedServer.PrivateDnsName}:${AiUnlimitedUiPort}/healthcheck
-      - !Sub http://${AiUnlimitedServer.PrivateDnsName}
+    Value: !Sub http://${AiUnlimitedServer.PrivateDnsName}
 
   AiUnlimitedPublicAPIAccess:
     Description: Teradata AI Unlimited public API Access

--- a/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
@@ -159,7 +159,7 @@ Parameters:
   JupyterVersion:
     Description: Which version of Jupyter to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.0.49
+    Default: v0.0.51
 
   RootVolumeSize:
     Description: size of the root disk to the AI Unlimited server.
@@ -744,6 +744,21 @@ Resources:
         - FromPort: 80
           IpProtocol: tcp
           ToPort: 80
+          CidrIp: !If
+            - HASCIDR
+            - !Ref AccessCIDR
+            - !Ref AWS::NoValue
+          SourcePrefixListId: !If
+            - HASPREFIXLIST
+            - !Ref PrefixList
+            - !Ref AWS::NoValue
+          SourceSecurityGroupId: !If
+            - HASSECURITYGROUP
+            - !Ref SecurityGroup
+            - !Ref AWS::NoValue
+        - FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
           CidrIp: !If
             - HASCIDR
             - !Ref AccessCIDR

--- a/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
+++ b/deployments/aws/templates/all-in-one/all-in-one-without-lb.yaml
@@ -136,7 +136,7 @@ Parameters:
   AiUnlimitedVersion:
     Description: Which version of AI Unlimited to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.3.0
+    Default: v0.3.2
 
   AiUnlimitedSchedulerVersion:
     Description: Which version of AI Unlimited Scheduler to deploy, uses container version tags, defaults to "latest"
@@ -146,7 +146,7 @@ Parameters:
   AiUnlimitedUiVersion:
     Description: Which version of AI Unlimited UI to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.0.6
+    Default: v0.0.7
 
   JupyterHttpPort:
     Description: port to access the Jupyter UI.

--- a/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
@@ -119,7 +119,7 @@ Parameters:
   JupyterVersion:
     Description: Which version of jupyter to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.0.49
+    Default: v0.0.51
 
   RootVolumeSize:
     Description: size of the root disk to the jupyter server.

--- a/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-with-nlb.yaml
@@ -12,7 +12,6 @@ Metadata:
           - InstanceType
           - RootVolumeSize
           - TerminationProtection
-          - JupyterToken
           - IamRole
           - IamRoleName
           - IamPermissionsBoundary

--- a/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
@@ -104,7 +104,7 @@ Parameters:
   JupyterVersion:
     Description: Which version of jupyter to deploy, uses container version tags, defaults to "latest"
     Type: String
-    Default: v0.0.49
+    Default: v0.0.51
 
   RootVolumeSize:
     Description: size of the root disk to the jupyter server.

--- a/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
+++ b/deployments/aws/templates/jupyter/jupyter-without-lb.yaml
@@ -12,7 +12,6 @@ Metadata:
           - InstanceType
           - RootVolumeSize
           - TerminationProtection
-          - JupyterToken
           - IamRole
           - IamRoleName
           - IamPermissionsBoundary

--- a/deployments/azure/scripts/ai-unlimited-ui.service
+++ b/deployments/azure/scripts/ai-unlimited-ui.service
@@ -15,14 +15,15 @@ ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull {0}/{1}:{2}
 
 ExecStart=/usr/bin/docker run \
-    -e TD_VCD_UI_PORT={3} \
+    -e TD_VCD_USE_TLS=false \
     -e TD_VCD_AUTH_PORT={4}\
     -e TD_VCD_API_PORT={5}\
     -e TD_VCD_INIT_API_KEY \
-    -v /etc/td/ai-unlimited:/etc/td \
-    -p {3}:80 \
+    -p 80:80 \
+    -p 443:443 \
+    -v ssl_certs:/etc/ssl/td \
     --network ai_unlimited {6} \
-    --rm --name %n {0}/{1}:{2}
+    --rm --name %n {0}/{1}:{2}   
 
 [Install]
 WantedBy=multi-user.target

--- a/deployments/azure/scripts/ai-unlimited.service
+++ b/deployments/azure/scripts/ai-unlimited.service
@@ -10,6 +10,7 @@ TimeoutStartSec=0
 Restart=always
 RestartSec=2
 EnvironmentFile=/etc/td/ai-unlimited/init_api_key.txt
+ExecStartPre=-/usr/bin/docker volume create ssl_certs
 ExecStartPre=-/usr/bin/docker network create -d bridge ai_unlimited
 ExecStartPre=-/usr/bin/mkdir -p /etc/td/ai-unlimited
 ExecStartPre=-/usr/bin/docker stop %n
@@ -23,9 +24,10 @@ ExecStart=/usr/bin/docker run \
     -e ARM_SUBSCRIPTION_ID={5} \
     -e ARM_TENANT_ID={6} \
     -e TD_VCD_INIT_API_KEY \
-    -v /etc/td/ai-unlimited:/etc/td \
     -p {3}:3000 \
     -p {4}:3282 \
+    -v /etc/td/ai-unlimited:/etc/td \
+    -v ssl_certs:/etc/td/ssl \
     --network ai_unlimited {7} \
     --rm --name %n {0}/{1}:{2} workspaces serve -v
 


### PR DESCRIPTION
* Add TLS/SSL port to Docker on AWS and Azure
* Add TLS variable to UI Docker container on AWS and Azure
* Create shared volume for UI and Server to share TLS certificate on AWS and Azure
* Removing parameter `AiUnlimitedUiPort` on AWS, UI port is not a user choice, it's port `80`
* Add port 443 to same places where port 80 is, on AWS

Pending to do in other PR:
* Do previous changes on other Azure files and big-template
* Removing parameter `{3}` on Azure, UI port is not a user choice, it's port `80`
* Add port 443 to same places where port 80 is, on Azure and big-template
